### PR TITLE
Unify field metadata into SQLCrucibleField with deferred forward-ref …

### DIFF
--- a/src/sqlcrucible/_types/forward_refs.py
+++ b/src/sqlcrucible/_types/forward_refs.py
@@ -45,7 +45,7 @@ def resolve_forward_refs(tp: Any, owner: type) -> Any:
     )
     globalns = vars(sys.modules[owner.__module__])
     localns = vars(owner)
-    hints = get_type_hints(temp, globalns=globalns, localns=localns)
+    hints = get_type_hints(temp, globalns=globalns, localns=localns, include_extras=True)
     return hints["_"]
 
 

--- a/src/sqlcrucible/entity/annotations.py
+++ b/src/sqlcrucible/entity/annotations.py
@@ -30,7 +30,7 @@ class SQLAlchemyField:
     tp: Any | None = None
 
     @classmethod
-    def merge_all(cls, *fields: "SQLAlchemyField | None") -> "SQLAlchemyField":
+    def merge_all(cls, *fields: SQLAlchemyField | None) -> SQLAlchemyField:
         """Merge multiple SQLAlchemyField annotations, with later values taking precedence."""
         result = SQLAlchemyField()
         for field in fields:

--- a/src/sqlcrucible/entity/automodel.py
+++ b/src/sqlcrucible/entity/automodel.py
@@ -9,7 +9,7 @@ import sqlalchemy.orm
 from sqlalchemy.orm.attributes import Mapped
 
 from sqlcrucible.entity.core import SQLAlchemyBase, SQLCrucibleEntity
-from sqlcrucible.entity.field_definitions import SQLAlchemyFieldDefinition
+from sqlcrucible.entity.field_definitions import SQLCrucibleField
 from sqlcrucible._types.forward_refs import resolve_forward_refs
 from sqlcrucible._types.transformer import (
     TypeTransformerChain,
@@ -77,14 +77,15 @@ def _create_automodel(source: type[SQLCrucibleEntity]) -> type[Any]:
     params = vars(source).get("__sqlalchemy_params__", {})
     base = _get_sa_base(source)
 
-    field_defs = source.__sqlalchemy_field_definitions__().values()
+    own_fields: dict[str, SQLCrucibleField] = source.__dict__.get("__sqlcrucible_fields__") or {}
+    field_defs = [decl for decl in own_fields.values() if not decl.excluded]
 
     # Determine which fields need type annotations based on SQLAlchemy's Mapped type.
     # Mapped represents attributes instrumented by the Mapper (columns, relationships),
     # which require annotations for SQLAlchemy to configure them. Non-Mapped descriptors
     # like hybrid_property and association_proxy are extensions that provide their own
     # functionality without mapper instrumentation, so they only need class attributes.
-    def needs_annotation(f: SQLAlchemyFieldDefinition) -> bool:
+    def needs_annotation(f: SQLCrucibleField) -> bool:
         return f.mapped_attr is None or isinstance(f.mapped_attr, Mapped)
 
     annotated_field_defs = [f for f in field_defs if needs_annotation(f)]
@@ -152,7 +153,7 @@ def _get_sa_base(annotation: type[SQLCrucibleEntity]) -> type[Any]:
 
 def _transform_field_type(
     owner: type[SQLCrucibleEntity],
-    field_def: SQLAlchemyFieldDefinition,
+    field_def: SQLCrucibleField,
 ) -> TypeTransformerResult:
     # Resolve any forward references in the source type first
     resolved_tp = resolve_forward_refs(field_def.source_tp, owner)

--- a/src/sqlcrucible/entity/core.py
+++ b/src/sqlcrucible/entity/core.py
@@ -8,13 +8,11 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Final,
     Generic,
     Literal,
     Self,
     TypeVar,
     cast,
-    get_origin,
 )
 
 from sqlalchemy import MetaData, Table
@@ -34,7 +32,12 @@ from sqlcrucible.entity.field_resolution import (
     get_to_sa_model_converter,
 )
 from sqlcrucible.conversion.caching import IdentityMap, _identity_map, CachingConverterFactory
-from sqlcrucible.entity.field_definitions import SQLAlchemyFieldDefinition
+from sqlcrucible.entity.field_definitions import (
+    CanonicalisedTypeform,
+    SQLCrucibleField,
+    ConversionStrategy,
+    canonicalise_typeform,
+)
 from sqlcrucible.entity.descriptors import ReadonlyFieldDescriptor
 
 
@@ -175,6 +178,7 @@ class SQLCrucibleEntity:
 
     __sqlalchemy_automodel__: ClassVar[SQLAlchemyModelType]
     __sqlalchemy_type__: ClassVar[SQLAlchemyModelType] = SQLAlchemyBase
+    __sqlcrucible_fields__: ClassVar[dict[str, SQLCrucibleField] | None] = None
     __sa_model__: SQLAlchemyModel | None = None
     __identity_map__: IdentityMap | None = None
 
@@ -186,43 +190,23 @@ class SQLCrucibleEntity:
         if "__sqlalchemy_type__" not in cls.__dict__:
             cls.__sqlalchemy_type__ = lazyproperty(_get_automodel)
 
-        annotations = get_annotations(cls, eval_str=True, format=Format.VALUE)
-        for key, ann in annotations.items():
-            origin = get_origin(ann)
-            if origin is ClassVar or origin is Final or ann is ClassVar or ann is Final:
+        # Register annotation-based fields as EAGER, skipping those already
+        # registered (e.g. by ReadonlyFieldDescriptor.__set_name__).
+        # get_annotations with FORWARDREF handles both stringified annotations
+        # (from __future__ import annotations) and Python 3.14+ lazy annotations
+        # (PEP 749), returning ForwardRef for unresolvable names. canonicalise_typeform
+        # wraps these in LazyCanonicalisedTypeform for deferred resolution.
+        registered = cls.__dict__.get("__sqlcrucible_fields__") or {}
+        for key, ann in get_annotations(cls, format=Format.FORWARDREF).items():
+            if key in registered:
                 continue
-            # Skip fields with readonly_field descriptor - they handle their own registration
-            if isinstance(cls.__dict__.get(key), ReadonlyFieldDescriptor):
-                continue
-            if (field_definition := SQLAlchemyFieldDefinition.from_typeform(key, ann)) is not None:
-                cls.__register_sqlalchemy_field_definition__(field_definition)
-
-    @classmethod
-    def __sqlalchemy_field_definitions__(cls) -> dict[str, SQLAlchemyFieldDefinition]:
-        if "_sqlalchemy_field_definitions" not in cls.__dict__:
-            cls._sqlalchemy_field_definitions = {}
-        return cls._sqlalchemy_field_definitions
-
-    @classmethod
-    def __mapped_fields__(cls) -> list[SQLAlchemyFieldDefinition]:
-        """Get field definitions for fields declared directly on this class.
-
-        Returns only fields that are both in the class's own annotations
-        (not inherited) and have SQLAlchemy field definitions registered.
-
-        Returns:
-            List of SQLAlchemyFieldDefinition for this class's own fields.
-        """
-        annotations = get_annotations(cls, eval_str=True, format=Format.VALUE)
-        return [
-            it
-            for it in cls.__sqlalchemy_field_definitions__().values()
-            if it.source_name in annotations
-        ]
+            canonical = canonicalise_typeform(cls, ann)
+            cls.__register_sqlcrucible_field__(key, canonical, ConversionStrategy.EAGER)
 
     @classmethod
     @cache
     def __to_sa_model_converters__(cls) -> list[FieldConverter]:
+        own_fields: dict[str, SQLCrucibleField] = cls.__dict__.get("__sqlcrucible_fields__") or {}
         return [
             *[
                 converter
@@ -232,19 +216,19 @@ class SQLCrucibleEntity:
             ],
             *[
                 FieldConverter(
-                    source_name=it.source_name,
-                    mapped_name=it.mapped_name,
-                    converter=get_to_sa_model_converter(cls, it),
+                    source_name=decl.source_name,
+                    mapped_name=decl.mapped_name,
+                    converter=get_to_sa_model_converter(cls, decl),
                 )
-                for it in cls.__mapped_fields__()
-                # Exclude readonly fields (defined via readonly_field descriptor)
-                if not it.readonly
+                for decl in own_fields.values()
+                if decl.conversion_strategy is ConversionStrategy.EAGER and not decl.excluded
             ],
         ]
 
     @classmethod
     @cache
     def __from_sa_model_converters__(cls) -> list[FieldConverter]:
+        own_fields: dict[str, SQLCrucibleField] = cls.__dict__.get("__sqlcrucible_fields__") or {}
         return [
             *[
                 converter
@@ -254,13 +238,12 @@ class SQLCrucibleEntity:
             ],
             *[
                 FieldConverter(
-                    source_name=it.source_name,
-                    mapped_name=it.mapped_name,
-                    converter=get_from_sa_model_converter(cls, it),
+                    source_name=decl.source_name,
+                    mapped_name=decl.mapped_name,
+                    converter=get_from_sa_model_converter(cls, decl),
                 )
-                for it in cls.__mapped_fields__()
-                # Exclude readonly fields (defined via readonly_field descriptor)
-                if not it.readonly
+                for decl in own_fields.values()
+                if decl.conversion_strategy is ConversionStrategy.EAGER and not decl.excluded
             ],
         ]
 
@@ -340,13 +323,30 @@ class SQLCrucibleEntity:
         return self.__sa_model__
 
     @classmethod
-    def __register_sqlalchemy_field_definition__(cls, field_def: SQLAlchemyFieldDefinition):
-        source_name = field_def.source_name
-        if source_name in cls.__sqlalchemy_field_definitions__():
+    def __register_sqlcrucible_field__(
+        cls,
+        source_name: str,
+        typeform: CanonicalisedTypeform,
+        conversion_strategy: ConversionStrategy = ConversionStrategy.EAGER,
+    ) -> None:
+        """Register a field's canonical type during class creation.
+
+        Used by ReadonlyFieldDescriptor.__set_name__ (DEFERRED) and
+        __init_subclass__ (EAGER) to build the master field registry.
+        """
+        defs = cls.__dict__.get("__sqlcrucible_fields__")
+        if defs is None:
+            defs = {}
+            cls.__sqlcrucible_fields__ = defs
+        if source_name in defs:
             logger.debug(
-                f"Multiple definition of SQLAlchemy field {source_name} in class {cls} and its bases; will prefer the latest"
+                f"Multiple definitions of SQLCrucible field for {source_name} in class {cls}; will prefer the latest"
             )
-        cls.__sqlalchemy_field_definitions__()[source_name] = field_def
+        defs[source_name] = SQLCrucibleField(
+            source_name=source_name,
+            typeform=typeform,
+            conversion_strategy=conversion_strategy,
+        )
 
 
 class SQLCrucibleBaseModel(BaseModel, SQLCrucibleEntity):

--- a/src/sqlcrucible/entity/descriptors.py
+++ b/src/sqlcrucible/entity/descriptors.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -22,8 +21,11 @@ from sqlcrucible.conversion.caching import _identity_map
 from sqlcrucible.entity.field_resolution import get_from_sa_model_converter
 from sqlcrucible.conversion.registry import Converter
 from sqlcrucible.entity.annotations import SQLAlchemyField
-from sqlcrucible.entity.field_definitions import SQLAlchemyFieldDefinition
-from sqlcrucible._types.forward_refs import resolve_forward_refs
+from sqlcrucible.entity.field_definitions import (
+    ConversionStrategy,
+    canonicalise_typeform,
+    SQLCrucibleField,
+)
 from typing_extensions import get_annotations, Format
 
 if TYPE_CHECKING:
@@ -68,16 +70,16 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
         self._descriptor = descriptor
         self._sa_field = sa_field
         self._converter: Converter[Any, _T] | None = None
-        self._sa_field_info: SQLAlchemyFieldDefinition | None = None
+        self._sa_field_info: SQLCrucibleField | None = None
         self._name: str | None = None
         self._owner: type[_O] | None = None
 
     def __set_name__(self, owner: type[_O], name: str):
         """Called when the descriptor is assigned to a class attribute.
 
-        Registers the field definition with the entity class.
-        Forward references in the type are resolved lazily when the field
-        definition is actually accessed, not during class creation.
+        Registers the canonical type with the entity class so that
+        the field definition can be resolved later.
+        Forward references are deferred via LazyCanonicalisedTypeform.
 
         Args:
             owner: The entity class owning this field
@@ -89,24 +91,19 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
         # Build SQLAlchemyField from provided arguments or extract from annotation
         sa_field = self._sa_field
         if self._descriptor is not None:
-            # Merge descriptor into sa_field (or create new one if sa_field is None)
             sa_field = SQLAlchemyField.merge_all(
                 sa_field,
                 SQLAlchemyField(attr=self._descriptor),
             )
         elif sa_field is None:
-            # Try to extract from annotation
             sa_field = self._extract_sa_field_from_annotation(owner, name)
 
-        # Register a preliminary field definition without resolving forward refs yet.
-        # The type will contain unresolved forward refs, but that's OK - they'll be
-        # resolved when the automodel is generated (lazily) or when the field is accessed.
-        sa_field_info = SQLAlchemyFieldDefinition.from_sqlalchemy_field(
-            self._name, self._tp, sa_field
+        # Build the type to canonicalise: wrap with Annotated if there's an sa_field
+        typeform = Annotated[self._tp, sa_field] if sa_field is not None else self._tp
+        canonical = canonicalise_typeform(owner, typeform)
+        owner.__register_sqlcrucible_field__(
+            name, canonical, conversion_strategy=ConversionStrategy.DEFERRED
         )
-        # Mark as readonly so it's excluded from to/from SA model converters
-        sa_field_info = replace(sa_field_info, readonly=True)
-        owner.__register_sqlalchemy_field_definition__(sa_field_info)
 
     def _extract_sa_field_from_annotation(
         self, owner: type[_O], name: str
@@ -126,15 +123,11 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
         return SQLAlchemyField(attr=descriptor) if descriptor else None
 
     @property
-    def sa_field_info(self) -> SQLAlchemyFieldDefinition:
-        """Get the SQLAlchemy field definition for this descriptor.
-
-        This property resolves any forward references in the type, which requires
-        all referenced classes to be defined. It's safe to call after class creation
-        is complete.
+    def sa_field_info(self) -> SQLCrucibleField:
+        """Get the field definition for this descriptor.
 
         Returns:
-            The field definition with resolved types
+            The SQLCrucibleField with resolved types
 
         Raises:
             RuntimeError: If accessed before the descriptor is assigned to a class
@@ -144,11 +137,10 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
                 raise RuntimeError(
                     "Attempted to construct SQLAlchemyFieldInfo on `readonly_field` descriptor before descriptor is assigned to a field!"
                 )
-            # Resolve forward references using the owner class's context
-            resolved_tp = resolve_forward_refs(self._tp, self._owner)
-            self._sa_field_info = SQLAlchemyFieldDefinition.from_sqlalchemy_field(
-                self._name, resolved_tp, self._sa_field
+            fields: dict[str, SQLCrucibleField] = (
+                self._owner.__dict__.get("__sqlcrucible_fields__") or {}
             )
+            self._sa_field_info = fields[self._name]
         return self._sa_field_info
 
     @overload

--- a/src/sqlcrucible/entity/field_definitions.py
+++ b/src/sqlcrucible/entity/field_definitions.py
@@ -1,10 +1,15 @@
 """Internal metadata structures for entity field definitions."""
 
 from __future__ import annotations
+from sqlalchemy.util import partial
+from sqlcrucible._types.forward_refs import resolve_forward_refs
+from collections.abc import Callable
+from enum import Enum, auto
+from functools import cached_property
 
 import typing
-from dataclasses import dataclass, replace
-from typing import Annotated, Any, Self, get_args, get_origin
+from dataclasses import dataclass
+from typing import Annotated, Any, ClassVar, get_args, get_origin, ForwardRef
 
 import sqlalchemy.orm
 from sqlalchemy.orm import ORMDescriptor
@@ -88,12 +93,8 @@ def _extract_annotation_metadata(annotations: tuple[Any, ...]) -> AnnotationMeta
 
 
 @dataclass(frozen=True, slots=True)
-class CanonicalisedTypeform:
-    """Normalized representation of a type annotation.
-
-    This represents the result of processing a type annotation to extract
-    SQLAlchemy field configuration, custom converters, and the base type.
-    """
+class ConcreteCanonicalisedTypeform:
+    """Fully resolved representation of a type annotation."""
 
     tp: Any
     field: SQLAlchemyField | None
@@ -101,177 +102,174 @@ class CanonicalisedTypeform:
     to_sa_converter: Converter | None = None
     should_exclude: bool | None = None
 
+    def resolve(self) -> ConcreteCanonicalisedTypeform:
+        return self
 
-@dataclass(frozen=True, slots=True)
-class SQLAlchemyFieldDefinition:
-    """Complete specification for mapping an entity field to SQLAlchemy.
+    def map(
+        self, fn: Callable[[ConcreteCanonicalisedTypeform], ConcreteCanonicalisedTypeform]
+    ) -> CanonicalisedTypeform:
+        return fn(self)
 
-    This class captures all the information needed to map a field from the
-    entity class to the corresponding SQLAlchemy model attribute, including
-    custom converters and type information.
 
-    Attributes:
-        source_name: Name of the field in the entity class
-        source_tp: Type of the field in the entity class
-        mapped_name: Name of the attribute in the SQLAlchemy model
-        mapped_tp: Type of the attribute in the SQLAlchemy model (if specified)
-        mapped_attr: ORM descriptor instance (if specified), e.g. hybrid_property
-        from_sa_converter: Custom converter from SA to entity (if specified)
-        to_sa_converter: Custom converter from entity to SA (if specified)
-        readonly: Whether this field is read-only (not included in converters)
+class LazyCanonicalisedTypeform:
+    """Deferred representation wrapping a supplier that produces a concrete typeform."""
+
+    __slots__ = ["_supplier", "_resolved"]
+
+    def __init__(self, supplier: Callable[[], CanonicalisedTypeform]) -> None:
+        self._supplier = supplier
+
+    def resolve(self) -> ConcreteCanonicalisedTypeform:
+        if not hasattr(self, "_resolved"):
+            result = self._supplier()
+            # Unwrap if the supplier returned another lazy
+            while isinstance(result, LazyCanonicalisedTypeform):
+                result = result.resolve()
+            self._resolved = result
+        return self._resolved
+
+    def map(
+        self, fn: Callable[[ConcreteCanonicalisedTypeform], ConcreteCanonicalisedTypeform]
+    ) -> CanonicalisedTypeform:
+        return LazyCanonicalisedTypeform(lambda: fn(self.resolve()))
+
+
+CanonicalisedTypeform = ConcreteCanonicalisedTypeform | LazyCanonicalisedTypeform
+
+
+def _contains_forward_ref(tp: Any) -> bool:
+    """Check if any type arguments contain forward references (recursively)."""
+    return isinstance(tp, (str, ForwardRef)) or any(
+        _contains_forward_ref(inner) for inner in get_args(tp)
+    )
+
+
+def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
+    """Process a type annotation to extract SQLAlchemy mapping information.
+
+    Recursively unwraps type annotations to extract the base type,
+    SQLAlchemyField configurations, custom converters, and exclusion markers.
+
+    Supported type forms:
+        - Annotated[T, ...]: Extracts metadata from annotations, recurses on T
+        - Mapped[T]: SQLAlchemy's Mapped wrapper, recurses on T
+        - str/ForwardRef: Deferred resolution via LazyCanonicalisedTypeform
+        - Any other type: Returns as-is with no field configuration
+
+    Args:
+        owner: The class that owns the annotation (for forward ref resolution)
+        typeform: The type annotation to process
+
+    Returns:
+        A CanonicalisedTypeform containing the extracted base type,
+        merged field configuration, and any custom converters.
+    """
+    match get_origin(typeform), get_args(typeform):
+        # Annotated[T, metadata...] - extract SQLCrucible metadata from annotations
+        case typing.Annotated, (tp, *annotations):
+            # Extract and categorize SQLCrucible-specific metadata
+            meta = _extract_annotation_metadata(tuple(annotations))
+
+            # Recurse into the inner type to handle nested Annotated/Mapped
+            inner = canonicalise_typeform(owner, tp)
+
+            return inner.map(partial(_merge_annotated, meta=meta))
+
+        # Mapped[T] - SQLAlchemy's type wrapper, unwrap and recurse
+        case sqlalchemy.orm.Mapped, (tp):
+            return canonicalise_typeform(owner, tp)
+
+        # ClassVar - class-level annotation, not an instance field
+        case _ if (get_origin(typeform) or typeform) is ClassVar:
+            return ConcreteCanonicalisedTypeform(tp=typeform, field=None, should_exclude=True)
+
+        # Forward ref or parameterized type with forward refs in args (e.g. list["Employee"])
+        case _ if _contains_forward_ref(typeform):
+
+            def _resolve_parameterized() -> CanonicalisedTypeform:
+                tp = resolve_forward_refs(typeform, owner)
+                return canonicalise_typeform(owner, tp)
+
+            return LazyCanonicalisedTypeform(supplier=_resolve_parameterized)
+
+        # Plain type (str, int, CustomClass, etc.) - no unwrapping needed
+        case _:
+            return ConcreteCanonicalisedTypeform(tp=typeform, field=None)
+
+
+def _merge_annotated(
+    inner: ConcreteCanonicalisedTypeform,
+    meta: AnnotationMetadata,
+) -> ConcreteCanonicalisedTypeform:
+    """Merge annotation metadata with an inner resolved typeform."""
+    fields = [it for it in (inner.field, *meta.fields) if it]
+    field = SQLAlchemyField.merge_all(*fields)
+    base_tp = inner.tp
+    source_tp = Annotated[base_tp, *meta.other_annotations] if meta.other_annotations else base_tp
+    return ConcreteCanonicalisedTypeform(
+        tp=source_tp,
+        field=field,
+        from_sa_converter=meta.from_sa_converter,
+        to_sa_converter=meta.to_sa_converter,
+        should_exclude=meta.should_exclude,
+    )
+
+
+class ConversionStrategy(Enum):
+    """How a field's value is obtained during entity conversion."""
+
+    EAGER = auto()
+    """Converted during from_sa_model()/to_sa_model()."""
+
+    DEFERRED = auto()
+    """Loaded on-demand from SA model via descriptor (readonly_field)."""
+
+
+@dataclass
+class SQLCrucibleField:
+    """A registered field with its canonical type and conversion strategy.
+
+    Exposes resolved mapping properties (source_tp, mapped_name, etc.) via
+    cached properties that resolve the typeform and merge field metadata on
+    first access.
     """
 
     source_name: str
-    source_tp: Any
+    typeform: CanonicalisedTypeform
+    conversion_strategy: ConversionStrategy
 
-    mapped_name: str
-    mapped_tp: Any | None = None
+    @cached_property
+    def _resolved(self) -> ConcreteCanonicalisedTypeform:
+        return self.typeform.resolve()
 
-    mapped_attr: ORMDescriptor[Any] | None = None
+    @cached_property
+    def _merged_field(self) -> SQLAlchemyField:
+        return SQLAlchemyField.merge_all(self._resolved.field, SQLAlchemyField())
 
-    from_sa_converter: Converter | None = None
-    to_sa_converter: Converter | None = None
+    @property
+    def excluded(self) -> bool:
+        return self._resolved.should_exclude or False
 
-    readonly: bool = False
+    @property
+    def source_tp(self) -> Any:
+        return self._resolved.tp
 
-    @classmethod
-    def from_sqlalchemy_field(
-        cls, source_name: str, source_tp: Any, field: SQLAlchemyField | None
-    ) -> Self:
-        """Create a field definition from a source type and SQLAlchemyField annotation.
+    @property
+    def mapped_name(self) -> str:
+        return self._merged_field.name or self.source_name
 
-        Args:
-            source_name: Name of the field in the entity
-            source_tp: Type annotation of the field
-            field: Optional SQLAlchemyField configuration
+    @property
+    def mapped_tp(self) -> Any | None:
+        return self._merged_field.tp
 
-        Returns:
-            A complete SQLAlchemyFieldDefinition
-        """
-        canonicalised = cls._canonicalise_typeform(source_name, source_tp)
-        field = SQLAlchemyField.merge_all(canonicalised.field, field or SQLAlchemyField())
-        return cls.from_canonicalised(source_name, replace(canonicalised, field=field))
+    @property
+    def mapped_attr(self) -> ORMDescriptor[Any] | None:
+        return self._merged_field.attr
 
-    @classmethod
-    def from_typeform(cls, source_name: str, typeform: Any) -> Self | None:
-        """Create a field definition from a type annotation.
+    @property
+    def from_sa_converter(self) -> Converter | None:
+        return self._resolved.from_sa_converter
 
-        This is used for processing field annotations to determine if they should
-        be mapped to SQLAlchemy. Returns None if the annotation doesn't contain
-        SQLAlchemy mapping information.
-
-        Args:
-            source_name: Name of the field in the entity
-            typeform: Type annotation to process
-
-        Returns:
-            A SQLAlchemyFieldDefinition if mapping info found, None otherwise
-        """
-        canonicalised = cls._canonicalise_typeform(source_name, typeform)
-        if canonicalised.should_exclude:
-            return None
-
-        return cls.from_canonicalised(source_name, canonicalised)
-
-    @classmethod
-    def from_canonicalised(cls, source_name: str, canonicalised: CanonicalisedTypeform) -> Self:
-        """Create a field definition from a canonicalised typeform.
-
-        Args:
-            source_name: Name of the field in the entity
-            canonicalised: The canonicalised type information
-
-        Returns:
-            A complete SQLAlchemyFieldDefinition
-        """
-        field = SQLAlchemyField.merge_all(canonicalised.field, SQLAlchemyField())
-        return cls(
-            source_name=source_name,
-            source_tp=canonicalised.tp,
-            mapped_name=field.name or source_name,
-            mapped_tp=field.tp,
-            mapped_attr=field.attr,
-            from_sa_converter=canonicalised.from_sa_converter,
-            to_sa_converter=canonicalised.to_sa_converter,
-        )
-
-    @classmethod
-    def _canonicalise_typeform(cls, source_name: str, typeform: Any) -> CanonicalisedTypeform:
-        """Process a type annotation to extract SQLAlchemy mapping information.
-
-        This method recursively unwraps type annotations to extract:
-        - The base type (after stripping Annotated, Mapped wrappers)
-        - SQLAlchemyField configurations (name, type, attr overrides)
-        - Custom converters (ConvertFromSAWith, ConvertToSAWith)
-        - Exclusion markers (ExcludeSAField)
-
-        The method handles nested annotations by recursively processing inner types
-        and merging the results. This allows annotations to be composed in any order.
-
-        Supported type forms:
-            - Annotated[T, ...]: Extracts metadata from annotations, recurses on T
-            - Mapped[T]: SQLAlchemy's Mapped wrapper, recurses on T
-            - Any other type: Returns as-is with no field configuration
-
-        Example processing:
-            Input:  Annotated[str, mapped_column(), SQLAlchemyField(name="db_name")]
-            Output: CanonicalisedTypeform(
-                tp=str,
-                field=SQLAlchemyField(name="db_name"),
-                ...
-            )
-
-            Input:  Annotated[timedelta, mapped_column(), ConvertToSAWith(lambda x: x.total_seconds())]
-            Output: CanonicalisedTypeform(
-                tp=timedelta,
-                field=SQLAlchemyField(),
-                to_sa_converter=FunctionConverter(...),
-                ...
-            )
-
-        Args:
-            source_name: Name of the field (for error messages)
-            typeform: The type annotation to process
-
-        Returns:
-            A CanonicalisedTypeform containing the extracted base type,
-            merged field configuration, and any custom converters.
-        """
-        match get_origin(typeform), get_args(typeform):
-            # Case 1: Annotated[T, metadata...] - extract SQLCrucible metadata from annotations
-            case typing.Annotated, (tp, *annotations):
-                tp, *annotations = get_args(typeform)
-
-                # Extract and categorize SQLCrucible-specific metadata
-                meta = _extract_annotation_metadata(tuple(annotations))
-
-                # Recurse into the inner type to handle nested Annotated/Mapped
-                inner = cls._canonicalise_typeform(source_name, tp)
-                fields = [it for it in (inner.field, *meta.fields) if it]
-
-                # Merge all field configs, with later values taking precedence
-                field = SQLAlchemyField.merge_all(*fields)
-                # Reconstruct Annotated if there are non-SQLCrucible annotations to preserve
-                source_tp = Annotated[tp, *meta.other_annotations] if meta.other_annotations else tp
-
-                return CanonicalisedTypeform(
-                    tp=source_tp,
-                    field=field,
-                    from_sa_converter=meta.from_sa_converter,
-                    to_sa_converter=meta.to_sa_converter,
-                    should_exclude=meta.should_exclude,
-                )
-            # Case 2: Mapped[T] - SQLAlchemy's type wrapper, unwrap and recurse
-            case sqlalchemy.orm.Mapped, (tp):
-                inner = cls._canonicalise_typeform(source_name, tp)
-                field = SQLAlchemyField.merge_all(inner.field, SQLAlchemyField())
-                return CanonicalisedTypeform(
-                    tp=inner.tp,
-                    field=field,
-                    from_sa_converter=inner.from_sa_converter,
-                    to_sa_converter=inner.to_sa_converter,
-                )
-
-            # Case 3: Plain type (str, int, CustomClass, etc.) - no unwrapping needed
-            case _:
-                return CanonicalisedTypeform(tp=typeform, field=None)
+    @property
+    def to_sa_converter(self) -> Converter | None:
+        return self._resolved.to_sa_converter

--- a/src/sqlcrucible/entity/field_resolution.py
+++ b/src/sqlcrucible/entity/field_resolution.py
@@ -21,7 +21,7 @@ from sqlcrucible._types.annotations import unwrap
 from sqlcrucible._types.forward_refs import evaluate_forward_refs
 
 if TYPE_CHECKING:
-    from sqlcrucible.entity.field_definitions import SQLAlchemyFieldDefinition
+    from sqlcrucible.entity.field_definitions import SQLCrucibleField
     from sqlcrucible.entity.core import SQLCrucibleEntity
 
 _T = TypeVar("_T")
@@ -36,7 +36,7 @@ class FieldConverter(Generic[_T, _S]):
     converter: Converter[_S, _T]
 
 
-def get_from_sa_model_converter(cls: type[_E], field_def: SQLAlchemyFieldDefinition) -> Converter:
+def get_from_sa_model_converter(cls: type[_E], field_def: SQLCrucibleField) -> Converter:
     if field_def.from_sa_converter:
         return field_def.from_sa_converter
 
@@ -53,7 +53,7 @@ def get_from_sa_model_converter(cls: type[_E], field_def: SQLAlchemyFieldDefinit
     return result
 
 
-def get_to_sa_model_converter(cls: type[_E], field_def: SQLAlchemyFieldDefinition) -> Converter:
+def get_to_sa_model_converter(cls: type[_E], field_def: SQLCrucibleField) -> Converter:
     if field_def.to_sa_converter:
         return field_def.to_sa_converter
 
@@ -104,7 +104,7 @@ def resolve_sa_field_type(sa_type: type, field_name: str) -> Any:
             return None
 
 
-def _get_sa_field_type(cls: type[_E], field_def: SQLAlchemyFieldDefinition) -> Any:
+def _get_sa_field_type(cls: type[_E], field_def: SQLCrucibleField) -> Any:
     if field_def.mapped_tp:
         return field_def.mapped_tp
 

--- a/tests/_types/test_forward_refs.py
+++ b/tests/_types/test_forward_refs.py
@@ -1,6 +1,7 @@
 """Tests for forward reference resolution utilities."""
 
 import pytest
+from typing import Annotated, get_args, get_origin
 
 from sqlcrucible._types.forward_refs import resolve_forward_refs
 
@@ -34,6 +35,19 @@ class Owner:
 def test_resolve_forward_refs(tp: object, expected: object) -> None:
     """Forward references are resolved in various type positions."""
     assert resolve_forward_refs(tp, Owner) == expected
+
+
+def test_resolve_preserves_annotated_metadata() -> None:
+    """Annotated metadata survives forward-ref resolution."""
+    sentinel = object()
+    tp = Annotated[list["Target"], sentinel]
+
+    resolved = resolve_forward_refs(tp, Owner)
+
+    assert get_origin(resolved) is Annotated
+    inner, *metadata = get_args(resolved)
+    assert inner == list[Target]
+    assert metadata == [sentinel]
 
 
 def test_resolve_already_resolved_type() -> None:

--- a/tests/entity/test_pydantic_entity.py
+++ b/tests/entity/test_pydantic_entity.py
@@ -13,7 +13,7 @@ from sqlcrucible.entity.descriptors import readonly_field
 
 from datetime import timedelta
 
-from typing import Annotated
+from typing import Annotated, ClassVar
 
 from sqlalchemy import MetaData, ForeignKey
 from sqlalchemy.orm import mapped_column, relationship
@@ -312,3 +312,20 @@ def test_model_json_schema_omits_readonly_descriptor_fields():
 
     assert "name" in schema["properties"]
     assert "artist" not in schema["properties"]
+
+
+def test_classvar_not_on_sa_model():
+    """ClassVar annotations are excluded from the generated SA model."""
+
+    class EntityWithClassVar(SQLCrucibleEntity, BaseModel):
+        __sqlalchemy_params__ = {"__tablename__": "classvar_test"}
+        id: Annotated[int, mapped_column(primary_key=True)]
+        name: Annotated[str, mapped_column()]
+        MAX_NAME_LENGTH: ClassVar[int] = 255
+
+    entity = EntityWithClassVar(id=1, name="Test")
+    sa_model = entity.to_sa_model()
+
+    assert sa_model.id == 1
+    assert sa_model.name == "Test"
+    assert not hasattr(sa_model, "MAX_NAME_LENGTH")


### PR DESCRIPTION
…resolution

Consolidate per-field metadata (SA column type, Pydantic field info, converters) into a single SQLCrucibleField dataclass with lazy resolution for forward references. Merge the two forward-ref match cases into one via a recursive _contains_forward_ref check, rename the entry point to canonicalise_typeform, move ClassVar detection into typeform canonicalisation, and adopt get_annotations (PEP 749) for Python 3.14 compatibility.