### PR TITLE
Tidy inline imports: hoist stdlib + test-local imports to top level

### DIFF
--- a/src/sqlcrucible/stubs/__init__.py
+++ b/src/sqlcrucible/stubs/__init__.py
@@ -5,6 +5,7 @@ Generates type stubs that provide type checker support for SAType[Entity] access
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 from typing import Any, Callable, Iterable, TypeVar
 
@@ -48,8 +49,6 @@ def _stub_path(root: Path, module_name: str) -> Path:
 
 def _package_exists_in_source(package_name: str) -> bool:
     """Check if a package exists in the source (not just as a stub)."""
-    import importlib.util
-
     try:
         spec = importlib.util.find_spec(package_name)
         return spec is not None and spec.submodule_search_locations is not None

--- a/tests/entity/test_relationships_annotated_metadata.py
+++ b/tests/entity/test_relationships_annotated_metadata.py
@@ -5,11 +5,11 @@ non-SQLAlchemy metadata (e.g. access-control markers) alongside the
 relationship() descriptor.
 """
 
-from uuid import uuid4, UUID
 from typing import Annotated
+from uuid import UUID, uuid4
 
 from pydantic import Field
-from sqlalchemy import MetaData, ForeignKey
+from sqlalchemy import ForeignKey, MetaData, inspect
 from sqlalchemy.orm import mapped_column, relationship
 
 from sqlcrucible.entity.core import SQLCrucibleBaseModel
@@ -68,8 +68,6 @@ def test_relationship_field_with_non_sa_annotated_metadata_roundtrips():
 
 def test_sa_model_annotation_for_relationship_with_annotated_metadata_uses_list():
     """The SA model annotation for an Annotated relationship field should be Mapped[list[...]]."""
-    from sqlalchemy import inspect
-
     mapper = inspect(SAType[PostAnnotated])
     rel = next(r for r in mapper.relationships if r.key == "tags")
     assert rel.uselist is True


### PR DESCRIPTION
## Summary
Function-local imports cost a name resolution and a (potentially first-time) module load every call. These two were holding up the rest:

- ``stubs/__init__.py:_package_exists_in_source`` had ``import importlib.util`` in the body. Stdlib, no circular concern.
- ``tests/entity/test_relationships_annotated_metadata.py:test_sa_model_annotation_for_relationship_with_annotated_metadata_uses_list`` had ``from sqlalchemy import inspect`` inside the test body — same deal, plus the rest of that test file already imports from ``sqlalchemy``.

The remaining function-local imports — ``sqlcrucible.entity.automodel`` inside ``core._construct_automodel`` and ``sqlcrucible.entity.core.SQLCrucibleEntity`` inside the two ``sa_conversion`` ``matches`` factories — are genuine module-load cycle workarounds. They stay where they are.

Audited via ``uvx ruff check --select PLC0415 src tests``: the only remaining flags are those three intentional cycles.

## Test plan
- [ ] ``nox`` (full lint / typecheck / test matrix — green locally).