### PR TITLE
Add to_column_dict + to_columns; share column projection with to_sa_model

### DIFF
--- a/src/sqlcrucible/entity/column_projection.py
+++ b/src/sqlcrucible/entity/column_projection.py
@@ -1,0 +1,157 @@
+"""Project entity field values onto underlying SQLAlchemy columns.
+
+The pre-existing :func:`SQLCrucibleEntity.to_sa_model` flow constructs a
+fully-mapped SA instance, which means a composite-backed field enters
+the picture as a single composite attribute and SA's descriptor
+decomposes it into its underlying columns under the hood. That works
+fine for ``session.add`` style inserts, but bulk
+``insert(table).values(...)`` (Core-level) operates on the raw columns
+directly — it has no view of composites.
+
+This module exposes the same conversion machinery at the *column*
+level. :func:`classify_field_converters` walks an entity's existing
+to-SA converter chain and, by introspecting the SA mapper, partitions
+it into:
+
+* :class:`ColumnProjection` entries, which know which columns each
+  Pydantic field maps to and how to extract their values. Plain columns
+  yield a single-value tuple; composite columns yield the tuple from
+  the value's ``__composite_values__`` (the standard SA composite
+  protocol).
+
+* :class:`RelationshipProjection` entries, which carry the existing
+  converter so :meth:`SQLCrucibleEntity.to_sa_model` can keep handing
+  child entities to the SA constructor as relationship attributes.
+
+Composite expansion therefore relies only on SA's standard composite
+protocol — no special-casing for any concrete composite type.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import inspect
+
+from sqlcrucible.conversion.registry import Converter
+
+if TYPE_CHECKING:
+    from sqlcrucible.entity.core import SQLCrucibleEntity
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnProjection:
+    """A projection from one Pydantic field to one or more SA columns.
+
+    For a plain field, ``column_names`` is a one-tuple and the extractor
+    wraps the converted value in a one-tuple.
+
+    For a composite-backed field, ``column_names`` lists the underlying
+    columns in the same order as the value's ``__composite_values__``
+    tuple, and the extractor calls that protocol method to decompose
+    the converted value.
+    """
+
+    source_name: str
+    """Pydantic field name on the entity."""
+
+    column_names: tuple[str, ...]
+    """SA column names this field projects onto, in the order their values
+    are returned by :attr:`extractor`."""
+
+    extractor: Callable[[Any], tuple[Any, ...]]
+    """Pydantic value → tuple of column values. Applies the existing
+    :class:`Converter` first (so any ``ConvertToSAWith`` customisation
+    is honoured), then decomposes via the composite protocol where
+    applicable."""
+
+
+@dataclass(frozen=True, slots=True)
+class RelationshipProjection:
+    """A field whose mapped attribute is a SA relationship rather than a
+    column. Held aside from column projections so consumers building
+    raw column dicts (for bulk Core-level inserts etc.) can ignore them."""
+
+    source_name: str
+    mapped_name: str
+    converter: Converter
+
+
+def classify_field_converters(
+    cls: type[SQLCrucibleEntity],
+) -> tuple[list[ColumnProjection], list[RelationshipProjection]]:
+    """Partition an entity's to-SA converters into column and relationship
+    projections by consulting the SA mapper.
+
+    The ordering of column projections matches the converter chain
+    (which in turn walks base classes first, then own fields), so
+    callers can rely on a stable iteration order.
+
+    Mapped attributes that don't correspond to a known mapper property
+    (e.g. ``hybrid_property``, ORM-only descriptors with no underlying
+    column) are emitted as :class:`RelationshipProjection` entries —
+    same shape as today's :meth:`to_sa_model`, which passes them as
+    kwargs to the SA constructor.
+    """
+    mapper = inspect(cls.__sqlalchemy_type__)
+    composites = {prop.key: prop for prop in mapper.composites}
+    columns = {prop.key: prop for prop in mapper.column_attrs}
+    specs = list(cls.__to_sa_model_converters__())
+
+    column_projections = [
+        _composite_projection(spec.source_name, spec.converter, composites[spec.mapped_name])
+        if spec.mapped_name in composites
+        else _column_projection(spec.source_name, spec.converter, columns[spec.mapped_name])
+        for spec in specs
+        if spec.mapped_name in composites or spec.mapped_name in columns
+    ]
+    relationship_projections = [
+        RelationshipProjection(
+            source_name=spec.source_name,
+            mapped_name=spec.mapped_name,
+            converter=spec.converter,
+        )
+        for spec in specs
+        if spec.mapped_name not in composites and spec.mapped_name not in columns
+    ]
+    return column_projections, relationship_projections
+
+
+def _column_projection(
+    source_name: str, converter: Converter, column_property: Any
+) -> ColumnProjection:
+    column_name = column_property.columns[0].name
+
+    def extract(value: Any) -> tuple[Any, ...]:
+        return (converter.convert(value),)
+
+    return ColumnProjection(
+        source_name=source_name,
+        column_names=(column_name,),
+        extractor=extract,
+    )
+
+
+def _composite_projection(
+    source_name: str, converter: Converter, composite_property: Any
+) -> ColumnProjection:
+    # ``CompositeProperty.columns`` is empty until mapper configure-time
+    # resolves them (and even then is sometimes empty); ``.props`` is
+    # the ColumnProperty list whose first column is what we want.
+    column_names = tuple(prop.columns[0].name for prop in composite_property.props)
+
+    def extract(value: Any) -> tuple[Any, ...]:
+        if value is None:
+            return (None,) * len(column_names)
+        converted = converter.convert(value)
+        if converted is None:
+            return (None,) * len(column_names)
+        return tuple(converted.__composite_values__())
+
+    return ColumnProjection(
+        source_name=source_name,
+        column_names=column_names,
+        extractor=extract,
+    )

--- a/src/sqlcrucible/entity/core.py
+++ b/src/sqlcrucible/entity/core.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     ClassVar,
     Generic,
+    Iterator,
     Literal,
     Self,
     TypeVar,
@@ -26,6 +27,11 @@ from sqlcrucible.entity.sa_conversion import (
     ToSAModelConverterFactory,
 )
 
+from sqlcrucible.entity.column_projection import (
+    ColumnProjection,
+    RelationshipProjection,
+    classify_field_converters,
+)
 from sqlcrucible.entity.field_resolution import (
     FieldConverter,
     get_from_sa_model_converter,
@@ -303,23 +309,88 @@ class SQLCrucibleEntity:
             identity_map[id(sa_model)] = result
             return result
 
+    @classmethod
+    @cache
+    def __classified_field_converters__(
+        cls,
+    ) -> tuple[list[ColumnProjection], list[RelationshipProjection]]:
+        """Cached partition of the to-SA converters into column projections
+        (for column-level outputs) and relationship projections (for the
+        nested-entity attributes the SA constructor accepts directly).
+
+        Built via :func:`classify_field_converters`, which consults the
+        SA mapper to dispatch each converter spec on the kind of property
+        its mapped name resolves to.
+        """
+        return classify_field_converters(cls)
+
+    @classmethod
+    def __column_projections__(cls) -> list[ColumnProjection]:
+        """Per-Pydantic-field projections onto SA columns. Plain fields
+        project to a single column; composite-backed fields decompose
+        into the underlying columns via SA's ``__composite_values__``
+        protocol. Excludes relationship-mapped fields."""
+        return cls.__classified_field_converters__()[0]
+
+    @classmethod
+    def __relationship_projections__(cls) -> list[RelationshipProjection]:
+        """Per-Pydantic-field projections onto SA relationship attributes.
+        Held aside from column projections so :meth:`to_column_dict`
+        consumers can ignore them when building bulk-INSERT payloads."""
+        return cls.__classified_field_converters__()[1]
+
+    def to_columns(self) -> Iterator[tuple[str, Any]]:
+        """Yield ``(column_name, value)`` pairs for every column-bound field
+        on this entity.
+
+        Plain fields yield a single pair; composite-backed fields yield
+        one pair per underlying column via SA's standard
+        ``__composite_values__`` protocol. Relationship-mapped fields
+        are excluded.
+
+        For joined-table inheritance the iteration spans every ancestor
+        table; consumers targeting a single table can post-filter via
+        ``Table.c``.
+        """
+        return (
+            (column_name, column_value)
+            for projection in self.__class__.__column_projections__()
+            for column_name, column_value in zip(
+                projection.column_names,
+                projection.extractor(getattr(self, projection.source_name)),
+                strict=True,
+            )
+        )
+
+    def to_column_dict(self) -> dict[str, Any]:
+        """Project this entity onto a flat ``{column_name: value}`` dict
+        suitable for direct ``insert(table).values(...)``. Thin wrapper
+        around :meth:`to_columns` for callers that need a dict."""
+        return dict(self.to_columns())
+
     def to_sa_model(self) -> Any:
         """Convert this entity to a SQLAlchemy model instance.
 
         Creates a new SQLAlchemy model populated with data from this entity,
-        applying any configured type converters for each field.
+        applying any configured type converters for each field. Internally
+        splices :meth:`to_columns` (column-shaped pairs, including
+        decomposed composites) with the relationship-projection chain
+        (nested-entity attributes), so the column-projection logic is a
+        single source of truth shared with bulk-insert consumers.
 
         Returns:
             A SQLAlchemy model instance ready to be added to a session.
         """
-        kwargs = {
-            conversion_spec.mapped_name: conversion_spec.converter.convert(value)
-            for conversion_spec in self.__class__.__to_sa_model_converters__()
-            for value in (getattr(self, conversion_spec.source_name),)
-        }
-
         sa_type = self.__class__.__sqlalchemy_type__
-        self.__sa_model__ = sa_type(**kwargs)
+        self.__sa_model__ = sa_type(
+            **dict(self.to_columns()),
+            **{
+                projection.mapped_name: projection.converter.convert(
+                    getattr(self, projection.source_name)
+                )
+                for projection in self.__class__.__relationship_projections__()
+            },
+        )
         return self.__sa_model__
 
     @classmethod

--- a/tests/entity/composite/__init__.py
+++ b/tests/entity/composite/__init__.py
@@ -1,0 +1,17 @@
+"""Tests for composite-backed fields.
+
+A composite field is one Pydantic attribute that decomposes into several
+SA columns via :func:`sqlalchemy.orm.composite` and the
+``__composite_values__`` protocol. SQLCrucible's two output paths must
+agree on the wire format:
+
+* :meth:`to_sa_model` constructs an SA instance whose composite
+  descriptor decomposes the value into its underlying columns on
+  persist.
+
+* :meth:`to_column_dict` produces a flat ``{column_name: value}`` dict
+  usable directly with Core-level bulk inserts, with the same column
+  values the composite descriptor would have decomposed into.
+
+The two paths share a single column projection so they can't drift.
+"""

--- a/tests/entity/composite/conftest.py
+++ b/tests/entity/composite/conftest.py
@@ -1,0 +1,74 @@
+"""Shared fixtures and entity definitions for composite-field tests."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import Column, Integer, MetaData, String
+from sqlalchemy.orm import Mapped, composite, mapped_column
+
+from sqlcrucible.entity.annotations import SQLAlchemyField
+from sqlcrucible.entity.core import SQLCrucibleBaseModel
+
+
+class Money(BaseModel):
+    """Composite value class. Implements SA's composite protocol via
+    ``__composite_values__``; Pydantic gives us validation, equality
+    and an immutable shape. The positional ``__init__`` overload
+    matches the call SA's composite descriptor makes when reading a
+    row back from the DB (``Money(amount, currency)``)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    amount: int
+    currency: str
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        if args and not kwargs:
+            amount, currency = args
+            super().__init__(amount=amount, currency=currency)
+        else:
+            super().__init__(**kwargs)
+
+    def __composite_values__(self) -> tuple[int, str]:
+        return (self.amount, self.currency)
+
+
+class _MoneyDescriptor(Mapped):
+    """Class-attribute marker that injects two SA columns + a
+    ``composite()`` at class-build time. Subclasses ``Mapped`` so
+    SQLCrucible recognises it as a column-bearing attribute and emits
+    the matching ``Mapped[Money]`` annotation."""
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        amount_col_name = f"{name}_amount"
+        currency_col_name = f"{name}_currency"
+        setattr(owner, amount_col_name, Column(Integer, nullable=True))
+        setattr(owner, currency_col_name, Column(String, nullable=True))
+        setattr(owner, name, composite(Money, amount_col_name, currency_col_name))
+
+
+def money_composite() -> SQLAlchemyField:
+    return SQLAlchemyField(attr=_MoneyDescriptor())
+
+
+class _Base(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": MetaData()}
+
+
+class Product(_Base):
+    __sqlalchemy_params__ = {"__tablename__": "product"}
+
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    name: str
+    price: Annotated[Money, money_composite()]
+
+
+class NullableProduct(_Base):
+    __sqlalchemy_params__ = {"__tablename__": "nullable_product"}
+
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    name: str
+    price: Annotated[Money | None, money_composite()] = None

--- a/tests/entity/composite/test_from_sa_model.py
+++ b/tests/entity/composite/test_from_sa_model.py
@@ -1,0 +1,30 @@
+"""Reading composite-backed fields back into entity instances."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlcrucible.entity.sa_type import SAType
+
+from tests.entity.composite.conftest import Money, Product
+
+
+def test_from_sa_model_reconstructs_entity_with_composite():
+    sa_model = SAType[Product](
+        id=uuid4(),
+        name="Book",
+        price_amount=1500,
+        price_currency="GBP",
+    )
+    product = Product.from_sa_model(sa_model)
+    assert product.price == Money(amount=1500, currency="GBP")
+
+
+def test_roundtrip_through_sa_preserves_composite_value():
+    pid = uuid4()
+    original = Product(id=pid, name="Book", price=Money(amount=1500, currency="GBP"))
+    sa_model = original.to_sa_model()
+    roundtripped = Product.from_sa_model(sa_model)
+    assert roundtripped.id == pid
+    assert roundtripped.name == "Book"
+    assert roundtripped.price == Money(amount=1500, currency="GBP")

--- a/tests/entity/composite/test_projections.py
+++ b/tests/entity/composite/test_projections.py
@@ -1,0 +1,27 @@
+"""Inspecting the projection metadata for composite-backed fields."""
+
+from __future__ import annotations
+
+from tests.entity.composite.conftest import Money, Product
+
+
+def test_column_projection_for_composite_lists_underlying_columns_in_order():
+    [price_proj] = [
+        proj for proj in Product.__column_projections__() if proj.source_name == "price"
+    ]
+    assert price_proj.column_names == ("price_amount", "price_currency")
+
+
+def test_column_projection_for_composite_extractor_calls_composite_values():
+    """The extractor honours the standard ``__composite_values__``
+    protocol — no special-casing for any concrete composite type."""
+    [price_proj] = [
+        proj for proj in Product.__column_projections__() if proj.source_name == "price"
+    ]
+    assert price_proj.extractor(Money(amount=42, currency="USD")) == (42, "USD")
+
+
+def test_column_projection_for_plain_field_is_a_one_tuple():
+    [name_proj] = [proj for proj in Product.__column_projections__() if proj.source_name == "name"]
+    assert name_proj.column_names == ("name",)
+    assert name_proj.extractor("Book") == ("Book",)

--- a/tests/entity/composite/test_to_column_dict.py
+++ b/tests/entity/composite/test_to_column_dict.py
@@ -1,0 +1,49 @@
+"""Decomposing a composite-backed field into its underlying columns."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlcrucible.entity.sa_type import SAType
+
+from tests.entity.composite.conftest import Money, NullableProduct, Product
+
+
+def test_to_column_dict_decomposes_composite_into_underlying_columns():
+    """A ``Money`` value produces two columns — ``price_amount`` and
+    ``price_currency`` — each carrying the value the composite would
+    decompose into. The composite attribute name itself never appears
+    in the column dict, since there is no ``price`` column on the
+    underlying table."""
+    product = Product(name="Book", price=Money(amount=1500, currency="GBP"))
+    column_dict = product.to_column_dict()
+    assert column_dict["price_amount"] == 1500
+    assert column_dict["price_currency"] == "GBP"
+    assert "price" not in column_dict
+
+
+def test_to_column_dict_includes_plain_columns_alongside_composites():
+    pid = uuid4()
+    product = Product(id=pid, name="Book", price=Money(amount=1500, currency="GBP"))
+    column_dict = product.to_column_dict()
+    assert column_dict["id"] == pid
+    assert column_dict["name"] == "Book"
+
+
+def test_to_column_dict_keys_match_underlying_table_columns():
+    """The flat dict's key set is exactly the leaf table's column names —
+    every key is a real column we can hand to a Core-level insert."""
+    product = Product(name="Book", price=Money(amount=1500, currency="GBP"))
+    column_dict = product.to_column_dict()
+    table = SAType[Product].__table__
+    assert set(column_dict.keys()) == {col.name for col in table.columns}
+
+
+def test_to_column_dict_handles_none_valued_composite():
+    """A nullable composite with a ``None`` value emits ``None`` for
+    every underlying column. This keeps the dict's shape stable across
+    rows, which matters for a multi-row Core-level insert batch."""
+    product = NullableProduct(name="Free Book", price=None)
+    column_dict = product.to_column_dict()
+    assert column_dict["price_amount"] is None
+    assert column_dict["price_currency"] is None

--- a/tests/entity/composite/test_to_sa_model.py
+++ b/tests/entity/composite/test_to_sa_model.py
@@ -1,0 +1,23 @@
+"""Composite-backed fields flow through ``to_sa_model`` correctly."""
+
+from __future__ import annotations
+
+from tests.entity.composite.conftest import Money, NullableProduct, Product
+
+
+def test_to_sa_model_with_composite_field_decomposes_correctly():
+    """``to_sa_model`` flows through the column projection — its kwargs
+    are the decomposed columns rather than a single composite
+    attribute. SA reconstructs the composite on read."""
+    product = Product(name="Book", price=Money(amount=1500, currency="GBP"))
+    sa_model = product.to_sa_model()
+    assert sa_model.price_amount == 1500
+    assert sa_model.price_currency == "GBP"
+    assert sa_model.price == Money(amount=1500, currency="GBP")
+
+
+def test_to_sa_model_with_nullable_composite_set_to_none():
+    product = NullableProduct(name="Free Book", price=None)
+    sa_model = product.to_sa_model()
+    assert sa_model.price_amount is None
+    assert sa_model.price_currency is None


### PR DESCRIPTION
## Summary

- Adds ``to_columns()`` (generator of ``(column_name, value)`` pairs) and ``to_column_dict()`` (dict wrapper) to ``SQLCrucibleEntity``, projecting an entity onto its underlying SA columns directly. Composite-backed fields are decomposed via the standard ``__composite_values__`` protocol; relationship-mapped fields are excluded.
- Refactors ``to_sa_model()`` to compose ``to_columns()`` with the relationship-projection chain so the column-projection logic is a single source of truth shared by both consumers.
- Introduces ``ColumnProjection`` / ``RelationshipProjection`` dataclasses and ``classify_field_converters`` in a new ``column_projection`` module — driven entirely by SA mapper introspection, no special-casing for any concrete composite type.

## Test plan
- [x] All 423 pre-existing tests still pass.
- [x] New ``tests/entity/composite/`` directory adds 11 tests covering column-dict decomposition, ``to_sa_model`` round-trip, ``from_sa_model`` reconstruction, nullable composites, and projection metadata.
- [x] ``ruff check`` + ``ruff format --check`` clean on touched files.