### PR TITLE
Forward kwargs in SQLCrucibleEntity.__init_subclass__

### DIFF
--- a/src/sqlcrucible/entity/core.py
+++ b/src/sqlcrucible/entity/core.py
@@ -182,7 +182,14 @@ class SQLCrucibleEntity:
     __sa_model__: SQLAlchemyModel | None = None
     __identity_map__: IdentityMap | None = None
 
-    def __init_subclass__(cls) -> None:
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        # Forward ``**kwargs`` so ``__init_subclass__`` cooperators further up
+        # the MRO still run — most importantly ``typing.Generic.__init_subclass__``,
+        # which populates ``__parameters__``. Without the super() call, a class
+        # that inherits from both ``SQLCrucibleEntity`` and ``Generic[T]`` looks
+        # un-parameterised to Pydantic, which then refuses to subscript it
+        # ("does not inherit from typing.Generic").
+        super().__init_subclass__(**kwargs)
         if "__sqlalchemy_automodel__" not in cls.__dict__:
             cls.__sqlalchemy_automodel__ = lazyproperty(_construct_automodel)
 

--- a/tests/entity/test_generic_entity.py
+++ b/tests/entity/test_generic_entity.py
@@ -1,0 +1,103 @@
+"""Regression: ``SQLCrucibleEntity.__init_subclass__`` cooperates with
+``typing.Generic.__init_subclass__``.
+
+Without ``super().__init_subclass__(**kwargs)`` propagating up the MRO,
+the typing machinery never gets to populate ``__parameters__`` on the
+class, and Pydantic refuses to subscript the class with
+"does not inherit from typing.Generic" (CPython 3.13+ even attaches a
+note pointing at this exact failure mode).
+"""
+
+from typing import Annotated, Generic, TypeVar
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, Field
+from sqlalchemy import MetaData, create_engine, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Session, mapped_column
+
+from sqlcrucible.entity.core import SQLCrucibleBaseModel, SQLCrucibleEntity
+from sqlcrucible.entity.sa_type import SAType
+
+
+T = TypeVar("T")
+P = TypeVar("P", bound=BaseModel)
+
+
+class BaseTestEntity(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": MetaData()}
+
+
+def test_sqlcrucible_entity_subclass_preserves_generic_parameters():
+    """Subclassing both ``SQLCrucibleEntity`` and ``Generic[P]`` must
+    leave ``__parameters__`` populated by ``typing.Generic``."""
+
+    class Container(SQLCrucibleEntity, Generic[P]):
+        pass
+
+    assert getattr(Container, "__parameters__", ()) == (P,)
+
+
+def test_pydantic_entity_subclass_can_be_parameterised():
+    """``BaseModel`` + ``SQLCrucibleEntity`` + ``Generic[P]`` should
+    accept Pydantic's ``Container[Concrete]`` subscript without
+    raising 'does not inherit from typing.Generic'."""
+
+    class Inner(BaseModel):
+        x: int
+
+    class Container(BaseTestEntity, Generic[P]):
+        __sqlalchemy_params__ = {"__tablename__": "_generic_container"}
+
+        id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+        payload: Annotated[P, mapped_column(JSONB, nullable=True)]
+
+    Specialised = Container[Inner]
+    assert Specialised.__pydantic_generic_metadata__["args"] == (Inner,)
+
+
+_DB_ROUNDTRIP_METADATA = MetaData()
+
+
+class _DBRoundTripBase(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": _DB_ROUNDTRIP_METADATA}
+
+
+class GenericContainer(_DBRoundTripBase, Generic[T]):
+    """Generic on ``T`` purely as a Pydantic-side type parameter; the
+    SA columns are concrete. Confirms ``__init_subclass__`` cooperation
+    survives the auto-model + table generation path that runs when
+    ``SAType[…]`` is first resolved on the generic base."""
+
+    __sqlalchemy_params__ = {"__tablename__": "_generic_container"}
+
+    id: Annotated[int, mapped_column(primary_key=True, autoincrement=True)] = None  # type: ignore[assignment]
+    label: Annotated[str, mapped_column(nullable=False)]
+
+
+@pytest.fixture
+def engine():
+    SAType[GenericContainer]
+    engine = create_engine("sqlite:///:memory:")
+    _DB_ROUNDTRIP_METADATA.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+def test_generic_entity_persists_and_reads_back(engine):
+    """A row inserted via the generic base reads back through the same
+    base; the generic parameter is irrelevant to the SA layer but the
+    auto-model + mapper had to be built without errors."""
+
+    written = GenericContainer(label="hello")
+
+    with Session(engine) as session:
+        session.add(written.to_sa_model())
+        session.commit()
+
+        loaded_sa = session.scalar(select(SAType[GenericContainer]))
+
+    assert loaded_sa is not None
+    loaded = GenericContainer.from_sa_model(loaded_sa)
+    assert loaded.label == "hello"


### PR DESCRIPTION
## Summary

`SQLCrucibleEntity.__init_subclass__` didn't accept `**kwargs` or call `super().__init_subclass__`, so any class inheriting from both `SQLCrucibleEntity` (or `SQLCrucibleBaseModel`) and `typing.Generic[T]` had its `__parameters__` left unset — `typing.Generic.__init_subclass__` never ran. Pydantic's `__class_getitem__` then refused to subscript the class with `does not inherit from typing.Generic`.

CPython 3.13+ explicitly anticipates this in `typing.py` and attaches a note suggesting an `__init_subclass__` cooperator that doesn't `super()` as the cause — that's exactly what was happening.

The fix is a one-line cooperative-MRO change: take `**kwargs` and chain to `super()`.

## Why this matters

It blocks Pydantic generics on top of SQLCrucible models. For example:

```python
class BaseEvent(SQLCrucibleBaseModel, Generic[P]):
    payload: P

LoanEvent = BaseEvent[LoanPayload]  # TypeError before this fix
```

## Test plan

- [x] New `tests/entity/test_generic_entity.py` — three regression cases:
  - `__parameters__` populates on a bare `SQLCrucibleEntity + Generic[P]` subclass
  - `SQLCrucibleBaseModel + Generic[P]` accepts Pydantic's `Container[Inner]` subscript
  - generic-marked entity with concrete SA columns persists + reads back via sqlite `Session`
- [x] Full nox `test` matrix green across Python 3.11 / 3.12 / 3.13 / 3.14 × Pydantic 2.10 / 2.11 / 2.12 (10 sessions)
- [x] `nox -s check` (ruff format + lint) clean
- [x] `nox -s typecheck` clean for both pyright and ty