### PR TITLE
Reuse the origin's automodel for transparent generic parameterisations

### DIFF
--- a/src/sqlcrucible/entity/automodel.py
+++ b/src/sqlcrucible/entity/automodel.py
@@ -67,6 +67,40 @@ def _public_fields(it: dict[str, Any]) -> dict[str, Any]:
     return {name: it[name] for name in names}
 
 
+def _transparent_parameterisation_origin(
+    source: type[SQLCrucibleEntity],
+) -> type[SQLCrucibleEntity] | None:
+    """If ``source`` is a Pydantic generic parameterisation (``Origin[Args...]``)
+    that adds no SQLAlchemy configuration of its own, return ``Origin``.
+
+    Such a class is transparent at the SQLAlchemy layer — same table, same
+    columns, same mapper — because the type parameters only constrain the
+    entity-side (Pydantic) field types, which the parameterised class already
+    carries in its own ``model_fields`` / converters. So it should reuse the
+    origin's automodel rather than mint a fresh one. Minting a fresh one is
+    not just wasteful: in single-table inheritance it lands as an identity-less
+    polymorphic intermediate (SQLAlchemy warns), and its ``__name__`` contains
+    ``[`` ``]`` which the stub generator can't emit as a valid identifier.
+
+    Returns ``None`` (build a fresh automodel as usual) when ``source`` adds
+    its own ``__sqlalchemy_params__``, ``__sqlalchemy_base__``, or registered
+    fields — e.g. a concrete subclass of a parameterised generic that supplies
+    its own ``polymorphic_identity``.
+    """
+    pydantic_meta = getattr(source, "__pydantic_generic_metadata__", None)
+    origin = pydantic_meta.get("origin") if pydantic_meta else None
+    is_parameterisation = origin is not None and origin is not source
+
+    own = vars(source)
+    adds_own_sa_config = bool(
+        own.get("__sqlalchemy_params__")
+        or own.get("__sqlalchemy_base__")
+        or own.get("__sqlcrucible_fields__")
+    )
+
+    return origin if is_parameterisation and not adds_own_sa_config else None
+
+
 def _create_automodel(source: type[SQLCrucibleEntity]) -> type[Any]:
     """Create a SQLAlchemy automodel class for an entity.
 
@@ -75,6 +109,9 @@ def _create_automodel(source: type[SQLCrucibleEntity]) -> type[Any]:
     mapper configuration, except when a cycle is detected (in which case string
     forward refs are used to break the cycle).
     """
+    if (origin := _transparent_parameterisation_origin(source)) is not None:
+        return origin.__sqlalchemy_type__
+
     params = vars(source).get("__sqlalchemy_params__", {})
     base = _get_sa_base(source)
 

--- a/src/sqlcrucible/stubs/codegen.py
+++ b/src/sqlcrucible/stubs/codegen.py
@@ -115,6 +115,19 @@ def specificity_order(entities: list[type[SQLCrucibleEntity]]) -> list[type[SQLC
     )
 
 
+def _is_parameterised_generic(entity: type) -> bool:
+    """A Pydantic generic parameterisation ``Origin[Args...]`` — created by
+    ``__class_getitem__`` with no class body of its own. Its automodel is the
+    origin's (see ``automodel._create_automodel``), so it needs no ``SAType``
+    overload: the origin's overload already covers it, since a parameterised
+    generic is a subtype of the unparameterised origin. Emitting one anyway
+    would also be malformed — ``fqn`` renders the type arguments inside the
+    subscript unqualified (the origin's ``__name__`` is literally
+    ``"Origin[Arg]"``)."""
+    origin = getattr(entity, "__pydantic_generic_metadata__", {}).get("origin")
+    return origin is not None and origin is not entity
+
+
 def construct_sa_type_stub(entities: list[type[SQLCrucibleEntity]]) -> str:
     """Construct a stub for SAType with @overload declarations.
 
@@ -125,6 +138,8 @@ def construct_sa_type_stub(entities: list[type[SQLCrucibleEntity]]) -> str:
     imports: set[str] = set()
     overloads: list[str] = []
     for entity in specificity_order(entities):
+        if _is_parameterised_generic(entity):
+            continue
         sa_type = entity.__sqlalchemy_type__
         imports.add(entity.__module__)
         imports.add(sa_type.__module__)

--- a/tests/entity/generic_sti_models.py
+++ b/tests/entity/generic_sti_models.py
@@ -1,0 +1,87 @@
+"""Sample generic single-table-inheritance hierarchy.
+
+A music-release table whose per-kind details live in a JSON column,
+typed via a generic ``Release[D]`` root. The parameterised intermediates
+``Release[SingleDetails]`` / ``Release[AlbumDetails]`` add nothing of
+their own at the SQLAlchemy layer, so they reuse ``Release``'s automodel;
+the concrete subclasses ``Single`` / ``Album`` carry their own
+``polymorphic_identity`` and get their own automodels extending
+``ReleaseAutoModel`` directly.
+
+Imported by ``test_generic_sti`` (including its stub-generation test,
+which loads this module by path).
+"""
+
+from typing import Annotated, Any, Generic, TypeVar
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+from sqlalchemy import JSON, MetaData, String
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.types import TypeDecorator
+
+from sqlcrucible.entity.annotations import ExcludeSAField
+from sqlcrucible.entity.core import SQLCrucibleBaseModel
+
+D = TypeVar("D", bound=BaseModel)
+
+generic_sti_metadata = MetaData()
+
+
+class PydanticJSON(TypeDecorator):
+    """Stores a Pydantic model as JSON — ``model_dump`` on bind, raw
+    dict on result (the consuming entity's field annotation re-validates).
+    A standalone, parameter-free TypeDecorator so it's usable as the
+    column type for a generic field annotated ``Mapped[D]``.
+
+    Defines ``python_type`` (which ``JSON`` doesn't) so stub generation
+    for *inherited* columns — where the subclass automodel doesn't carry
+    its own annotation — has something to fall back to."""
+
+    impl = JSON
+    cache_ok = True
+
+    @property
+    def python_type(self) -> type:
+        return dict
+
+    def process_bind_param(self, value: Any, dialect: Any) -> Any:
+        if isinstance(value, BaseModel):
+            return value.model_dump(mode="json")
+        return value
+
+    def process_result_value(self, value: Any, dialect: Any) -> Any:
+        return value
+
+
+class _Base(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": generic_sti_metadata}
+
+
+class Release(_Base, Generic[D]):
+    __sqlalchemy_params__ = {
+        "__tablename__": "release",
+        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_abstract": True},
+    }
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    kind: Annotated[str, mapped_column(String, nullable=False)]
+    details: Annotated[D, mapped_column(PydanticJSON(), nullable=True)]
+
+
+class SingleDetails(BaseModel):
+    a_side: str
+    b_side: str
+
+
+class AlbumDetails(BaseModel):
+    track_titles: list[str]
+
+
+class Single(Release[SingleDetails]):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "single"}}
+    kind: Annotated[str, ExcludeSAField()] = "single"
+
+
+class Album(Release[AlbumDetails]):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "album"}}
+    kind: Annotated[str, ExcludeSAField()] = "album"

--- a/tests/entity/test_generic_entity.py
+++ b/tests/entity/test_generic_entity.py
@@ -72,7 +72,7 @@ class GenericContainer(_DBRoundTripBase, Generic[T]):
 
     __sqlalchemy_params__ = {"__tablename__": "_generic_container"}
 
-    id: Annotated[int, mapped_column(primary_key=True, autoincrement=True)] = None  # type: ignore[assignment]
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
     label: Annotated[str, mapped_column(nullable=False)]
 
 

--- a/tests/entity/test_generic_sti.py
+++ b/tests/entity/test_generic_sti.py
@@ -1,0 +1,125 @@
+"""Single-table inheritance rooted at a Pydantic-generic class.
+
+A parameterised intermediate (``Release[SingleDetails]``) that adds
+nothing of its own at the SQLAlchemy layer reuses ``Release``'s automodel
+rather than minting a fresh one — which would otherwise land as an
+identity-less polymorphic intermediate (SQLAlchemy warns) with a
+bracket-laden ``__name__`` the stub generator can't emit. Concrete
+subclasses that supply their own ``polymorphic_identity`` still get their
+own automodels, extending ``ReleaseAutoModel`` directly.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session
+
+from sqlcrucible.entity.sa_type import SAType
+from sqlcrucible.stubs import generate_stubs
+
+from tests.entity.generic_sti_models import (
+    Album,
+    AlbumDetails,
+    Release,
+    Single,
+    SingleDetails,
+    generic_sti_metadata,
+)
+
+
+def test_parameterised_intermediate_reuses_origin_automodel():
+    assert SAType[Release[SingleDetails]] is SAType[Release]
+    assert SAType[Release[AlbumDetails]] is SAType[Release]
+
+
+def test_concrete_subclasses_get_own_automodels_extending_the_root_directly():
+    assert SAType[Single] is not SAType[Release]
+    assert SAType[Album] is not SAType[Release]
+    assert issubclass(SAType[Single], SAType[Release])
+    assert issubclass(SAType[Album], SAType[Release])
+    # No bracket-named intermediate sitting between subclass and root — so
+    # SQLAlchemy sees a clean STI chain (abstract root, concrete leaves)
+    # rather than an identity-less polymorphic middle class.
+    assert SAType[Single].__mro__[1] is SAType[Release]
+    assert SAType[Album].__mro__[1] is SAType[Release]
+
+
+@pytest.fixture
+def engine():
+    SAType[Single]
+    SAType[Album]
+    engine = create_engine("sqlite:///:memory:")
+    generic_sti_metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+def test_subclasses_round_trip_with_their_parameterised_payload_type(engine):
+    """Persist a ``Single`` and an ``Album`` (two concrete subclasses of
+    the same generic STI root), query them back, and get instances of the
+    right subclass whose ``details`` JSON column has been re-validated to
+    that subclass's parameterised Pydantic type — ``SingleDetails`` /
+    ``AlbumDetails`` — not the raw stored dict."""
+    with Session(engine) as session:
+        session.add(
+            Single(details=SingleDetails(a_side="Heroes", b_side="V-2 Schneider")).to_sa_model()
+        )
+        session.add(
+            Album(
+                details=AlbumDetails(track_titles=["Speed of Life", "Breaking Glass"])
+            ).to_sa_model()
+        )
+        session.commit()
+
+        singles = session.execute(select(SAType[Single])).scalars().all()
+        albums = session.execute(select(SAType[Album])).scalars().all()
+
+    [single] = [Single.from_sa_model(r) for r in singles]
+    assert isinstance(single.details, SingleDetails)
+    assert single.details.a_side == "Heroes"
+    assert single.details.b_side == "V-2 Schneider"
+    assert single.kind == "single"
+
+    [album] = [Album.from_sa_model(r) for r in albums]
+    assert isinstance(album.details, AlbumDetails)
+    assert album.details.track_titles == ["Speed of Life", "Breaking Glass"]
+    assert album.kind == "album"
+
+
+def test_polymorphic_query_through_root_dispatches_to_subclass(engine):
+    with Session(engine) as session:
+        session.add(
+            Single(details=SingleDetails(a_side="Heroes", b_side="V-2 Schneider")).to_sa_model()
+        )
+        session.commit()
+
+        row = session.execute(select(SAType[Release])).scalar_one()
+
+    assert isinstance(row, SAType[Single])
+
+
+def test_stub_generation_is_well_formed(tmp_path: Path):
+    """No bracket-named automodel class is created, so the generated
+    stubs contain no class whose name has ``[`` ``]``; the parameterised
+    intermediates get no ``SAType`` overload of their own (the origin's
+    covers them); and every ``.pyi`` parses as valid Python."""
+    generate_stubs(["tests.entity.generic_sti_models"], output_dir=str(tmp_path))
+
+    pyi_files = list(tmp_path.rglob("*.pyi"))
+    assert pyi_files, "expected generated .pyi files"
+
+    for pyi in pyi_files:
+        source = pyi.read_text()
+        # A bracket-named automodel would appear as e.g. `SingleDetails]AutoModel`;
+        # a parameterised-generic overload would reference `Release[SingleDetails]`.
+        assert "]AutoModel" not in source, f"{pyi} has a bracket-named automodel"
+        assert "Release[" not in source, f"{pyi} references a parameterised generic"
+        ast.parse(source, filename=str(pyi))  # SyntaxError on malformed output
+
+    sa_type_pyi = (tmp_path / "sqlcrucible" / "entity" / "sa_type.pyi").read_text()
+    # The concrete subclasses and the (abstract) origin do get overloads.
+    assert "tests.entity.generic_sti_models.Single]" in sa_type_pyi
+    assert "tests.entity.generic_sti_models.Album]" in sa_type_pyi
+    assert "tests.entity.generic_sti_models.Release]" in sa_type_pyi


### PR DESCRIPTION
## Summary

When Pydantic builds `Foo[X]` (via `__class_getitem__`) it creates a fresh class, and SQLCrucible was minting a fresh `Foo[X]AutoModel` for it. That auto-model is pointless at the SQLAlchemy layer — same table, same columns, same mapper; the type parameters only constrain the *entity-side* (Pydantic) field types, which `Foo[X]` already carries in its own `model_fields` / converters. And it actively breaks things:

- In single-table inheritance, `Foo[X]AutoModel` lands as an **identity-less polymorphic intermediate** between the root and a concrete subclass, so SQLAlchemy warns.
- Its `__name__` contains `[` `]`, which the **stub generator emitted verbatim** — `class Foo[X]AutoModel(...)` in a `.pyi` — unparseable.

Now `_create_automodel` short-circuits: if `source` is a Pydantic generic parameterisation (`__pydantic_generic_metadata__["origin"]` is set) that adds no SQLAlchemy config of its own — no own `__sqlalchemy_params__`, no `__sqlalchemy_base__`, no registered `__sqlcrucible_fields__` — it returns `origin.__sqlalchemy_type__` instead of building a new class. A concrete subclass that *does* add config (e.g. its own `polymorphic_identity`) isn't transparent, so it still gets its own automodel — which now extends the origin's automodel **directly**, with no identity-less intermediate.

The stub generator likewise skips `SAType` overloads for parameterised generics: the origin's overload already covers them (a parameterised generic is a subtype of the unparameterised origin), and emitting one anyway would render the type arguments inside the subscript unqualified (the origin's `__name__` is literally the string `"Origin[Arg]"`).

Net behavioural change: `SAType[Foo[X]] is SAType[Foo]`. If you `select(SAType[Foo[str]]).where(...)` you're really querying `FooAutoModel`; a row written through `Foo[int]` then fails validation when read back via `Foo[str].from_sa_model(...)` — correct ('you read with the wrong parameterisation').

## Example

A music-release table whose per-kind details live in a JSON column, typed via a generic `Release[D]` root:

```python
D = TypeVar("D", bound=BaseModel)

class Release(SQLCrucibleBaseModel, Generic[D]):
    __sqlalchemy_params__ = {
        "__tablename__": "release",
        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_abstract": True},
    }
    kind: Annotated[str, mapped_column(String)]
    details: Annotated[D, mapped_column(PydanticJSON(), nullable=True)]

class SingleDetails(BaseModel):
    a_side: str
    b_side: str

class AlbumDetails(BaseModel):
    track_titles: list[str]

class Single(Release[SingleDetails]):
    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "single"}}
    kind: Annotated[str, ExcludeSAField()] = "single"

class Album(Release[AlbumDetails]):
    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "album"}}
    kind: Annotated[str, ExcludeSAField()] = "album"
```

Before this PR: `Release[SingleDetails]AutoModel` is created, triggers the SAWarning, and breaks stub generation. After: it reuses `ReleaseAutoModel`; `SingleAutoModel` extends it directly; `polymorphic_abstract` on the root works as intended; stubs are clean. `Single.from_sa_model(row)` returns a `Single` whose `details` is a `SingleDetails` — Pydantic does the dict→model validation via the subclass's resolved field annotation; the SA column stays type-agnostic. Querying `SAType[Release]` (the abstract root) returns the concrete subclass instances via the usual polymorphic dispatch.

## Test plan

- [x] New `tests/entity/test_generic_sti.py` (+ `tests/entity/generic_sti_models.py` fixture — the `Release` / `Single` / `Album` hierarchy above):
  - `SAType[Release[X]] is SAType[Release]` for both parameterisations
  - `Single` / `Album` get their own automodels, extending `SAType[Release]` directly (`__mro__[1]`)
  - no `SAWarning` when resolving the automodels of a freshly-defined generic STI hierarchy
  - full DB round-trip (sqlite): write `Single(details=SingleDetails(...))` / `Album(...)`, read back through the concrete subclasses, `details` comes back typed
  - polymorphic query through the abstract root dispatches to the concrete subclass instance
  - stub generation emits no `]AutoModel` (bracket-named) class, no parameterised-generic overload, and every `.pyi` parses; the concrete subclasses and the abstract root still get overloads
- [x] Full nox `test` matrix green: Python 3.11 / 3.12 / 3.13 / 3.14 × Pydantic 2.10 / 2.11 / 2.12 (10 sessions, 444 tests)
- [x] `nox -s check` (ruff format + lint) clean
- [x] `nox -s typecheck` clean — pyright and ty