### PR TITLE
Pass a ConversionContext to ConvertFromSAWith / ConvertToSAWith callables

### DIFF
--- a/docs/guide/type-conversion.md
+++ b/docs/guide/type-conversion.md
@@ -2,7 +2,7 @@
 
 ## Custom Type Converters
 
-Use `ConvertToSAWith` and `ConvertFromSAWith` to customize conversion between your entity and the SQLAlchemy model:
+Use `ConvertToSAWith` and `ConvertFromSAWith` to customize conversion between your entity and the SQLAlchemy model. The callable receives `(value, context)` — `context` is a `ConversionContext`, and `context.target_type` is the resolved entity-side field type:
 
 ```python
 from datetime import timedelta
@@ -19,10 +19,50 @@ class Track(SQLCrucibleBaseModel):
         timedelta,
         mapped_column(),
         SQLAlchemyField(name="length_seconds", tp=int),
-        ConvertToSAWith(lambda td: td.total_seconds()),
-        ConvertFromSAWith(lambda s: timedelta(seconds=s)),
+        ConvertToSAWith(lambda td, ctx: td.total_seconds()),
+        ConvertFromSAWith(lambda s, ctx: timedelta(seconds=s)),
     ]
 ```
+
+### `target_type` and generic entities
+
+`context.target_type` is the *resolved* type of the field — for a concrete specialisation of a generic entity it's the specialised type, not the `TypeVar`. So a JSON column holding a per-subclass Pydantic payload can be re-validated against the right model:
+
+```python
+from typing import Annotated, Generic, TypeVar
+from pydantic import BaseModel, TypeAdapter
+from sqlalchemy import JSON
+from sqlalchemy.orm import mapped_column
+from sqlcrucible import ConvertFromSAWith, ConvertToSAWith, ExcludeSAField, SQLCrucibleBaseModel
+
+P = TypeVar("P", bound=BaseModel)
+
+class Event(SQLCrucibleBaseModel, Generic[P]):
+    __sqlalchemy_params__ = {
+        "__tablename__": "event",
+        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_abstract": True},
+    }
+    payload: Annotated[
+        P | None,
+        mapped_column(JSON, nullable=True),
+        ConvertToSAWith(lambda v, ctx: None if v is None else v.model_dump(mode="json")),
+        ConvertFromSAWith(
+            lambda v, ctx: None if v is None else TypeAdapter(ctx.target_type).validate_python(v)
+        ),
+    ] = None
+
+class ArtistSignedPayload(BaseModel):
+    artist_name: str
+
+class ArtistSigned(Event[ArtistSignedPayload]):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "artist.signed"}}
+    kind: Annotated[str, ExcludeSAField()] = "artist.signed"
+
+# Loading an ArtistSigned row: ctx.target_type is `ArtistSignedPayload | None`,
+# so `payload` comes back as an ArtistSignedPayload, not the raw dict.
+```
+
+Custom `Converter` implementations (registered directly in a `ConverterRegistry`) follow the same shape — `convert(self, source, context)` and `safe_convert(self, source, context)`.
 
 ## How the Conversion System Works
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -56,6 +56,12 @@
     options:
       show_bases: false
 
+### ConversionContext
+
+::: sqlcrucible.conversion.context.ConversionContext
+    options:
+      show_bases: false
+
 ## Fields
 
 ### readonly_field

--- a/src/sqlcrucible/__init__.py
+++ b/src/sqlcrucible/__init__.py
@@ -1,3 +1,4 @@
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.entity.core import SQLCrucibleBaseModel, SQLCrucibleEntity, SQLAlchemyParameters
 from sqlcrucible.entity.sa_type import SAType
 from sqlcrucible.entity.annotations import (
@@ -18,6 +19,7 @@ __all__ = [
     "ExcludeSAField",
     "ConvertFromSAWith",
     "ConvertToSAWith",
+    "ConversionContext",
     "readonly_field",
     "ReadonlyFieldDescriptor",
     "__version__",

--- a/src/sqlcrucible/conversion/caching.py
+++ b/src/sqlcrucible/conversion/caching.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Generator, TypeVar, Generic
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
 
 IdentityMap = dict[int, Any]
@@ -45,16 +46,16 @@ class CachingConverter(Generic[_T, _R], Converter[_T, _R]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return self._inner.matches(source_tp, target_tp)
 
-    def convert(self, source: _T) -> _R:
+    def convert(self, source: _T, context: ConversionContext) -> _R:
         with _identity_map() as identity_map:
             if id(source) not in identity_map:
-                identity_map[id(source)] = self._inner.convert(source)
+                identity_map[id(source)] = self._inner.convert(source, context)
             return identity_map[id(source)]
 
-    def safe_convert(self, source: _T) -> _R:
+    def safe_convert(self, source: _T, context: ConversionContext) -> _R:
         with _identity_map() as identity_map:
             if id(source) not in identity_map:
-                identity_map[id(source)] = self._inner.safe_convert(source)
+                identity_map[id(source)] = self._inner.safe_convert(source, context)
             return identity_map[id(source)]
 
 

--- a/src/sqlcrucible/conversion/context.py
+++ b/src/sqlcrucible/conversion/context.py
@@ -1,0 +1,21 @@
+"""Context handed to value converters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ConversionContext:
+    """Context handed to ``ConvertToSAWith`` / ``ConvertFromSAWith`` callables.
+
+    ``target_type`` is the *resolved* entity-side field type — for a concrete
+    specialisation of a generic entity it's the specialised type, not the
+    ``TypeVar`` — so a converter can validate against it (e.g. with
+    ``pydantic.TypeAdapter``) without having to guess. New fields can be added
+    here as more context is needed; the callable signature stays
+    ``Callable[[Any, ConversionContext], Any]``.
+    """
+
+    target_type: Any

--- a/src/sqlcrucible/conversion/dicts.py
+++ b/src/sqlcrucible/conversion/dicts.py
@@ -21,6 +21,7 @@ from typing import (
 )
 from typing_extensions import is_typeddict, NoExtraItems
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
 from sqlcrucible._types.annotations import TypeAnnotation, unwrap
 
@@ -167,18 +168,18 @@ class DictConverter(Converter[dict, dict]):
         if missing:
             raise TypeError(f"Missing required key '{missing}' for {self._target_info.tp}")
 
-    def convert(self, source: dict) -> dict:
+    def convert(self, source: dict, context: ConversionContext) -> dict:
         result = {
-            key: conv.convert(value)
+            key: conv.convert(value, context)
             for key, value in source.items()
             if (conv := self._get_converter(key))
         }
         self._check_required_fields(result)
         return result
 
-    def safe_convert(self, source: dict) -> dict:
+    def safe_convert(self, source: dict, context: ConversionContext) -> dict:
         result = {
-            key: conv.safe_convert(value)
+            key: conv.safe_convert(value, context)
             for key, value in source.items()
             if (conv := self._get_converter(key))
         }

--- a/src/sqlcrucible/conversion/function.py
+++ b/src/sqlcrucible/conversion/function.py
@@ -2,42 +2,45 @@
 
 This module provides a converter that wraps a user-supplied function to perform
 type conversion. It's used when fields are annotated with ConvertToSAWith or
-ConvertFromSAWith to specify custom conversion logic.
+ConvertFromSAWith to specify custom conversion logic. The function is called as
+``fn(value, context)``, where ``context`` is the
+:class:`~sqlcrucible.conversion.context.ConversionContext` for the field being
+converted (it carries the resolved field type).
 
 Example::
 
-    converter = FunctionConverter(lambda x: x.total_seconds())
-    converter.convert(timedelta(minutes=5))  # Returns 300.0
+    converter = FunctionConverter(lambda x, ctx: x.total_seconds())
+    converter.convert(timedelta(minutes=5), ConversionContext(target_type=float))  # 300.0
 """
 
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter
-
-_T = TypeVar("_T")
-_R = TypeVar("_R")
 
 
 class FunctionConverter(Converter[Any, Any]):
     """Converter that applies a custom function to transform values.
 
-    This converter always reports that it matches any type pair, since the
-    function itself determines what conversions are valid. Type checking
-    is the responsibility of the wrapped function.
-
-    Attributes:
-        _fn: The conversion function to apply.
+    Reports a match for any type pair — the wrapped function decides what's
+    valid; type checking is its responsibility. The function is invoked as
+    ``fn(value, context)`` with the :class:`ConversionContext` supplied by the
+    caller.
     """
 
-    def __init__(self, fn: Callable[[_T], _R]):
+    def __init__(self, fn: Callable[[Any, ConversionContext], Any]) -> None:
         self._fn = fn
+
+    @property
+    def fn(self) -> Callable[[Any, ConversionContext], Any]:
+        return self._fn
 
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return True
 
-    def convert(self, source: Any) -> Any:
-        return self._fn(source)
+    def convert(self, source: Any, context: ConversionContext) -> Any:
+        return self._fn(source, context)
 
-    def safe_convert(self, source: Any) -> Any:
-        return self.convert(source)
+    def safe_convert(self, source: Any, context: ConversionContext) -> Any:
+        return self.convert(source, context)

--- a/src/sqlcrucible/conversion/literals.py
+++ b/src/sqlcrucible/conversion/literals.py
@@ -12,6 +12,7 @@ Example:
 
 from typing import Any, Literal, get_args, get_origin
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.exceptions import TypeMismatchError
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
 from sqlcrucible._types.annotations import unwrap
@@ -62,10 +63,10 @@ class LiteralConverter(Converter[Any, Any]):
         target_values = _get_literal_values(target_tp)
         return source_values <= target_values
 
-    def convert(self, source: Any) -> Any:
+    def convert(self, source: Any, context: ConversionContext) -> Any:
         return source
 
-    def safe_convert(self, source: Any) -> Any:
+    def safe_convert(self, source: Any, context: ConversionContext) -> Any:
         if source not in self._allowed_values:
             raise TypeMismatchError(
                 source,

--- a/src/sqlcrucible/conversion/noop.py
+++ b/src/sqlcrucible/conversion/noop.py
@@ -16,6 +16,7 @@ from sqlcrucible._types.annotations import (
 from typing import Any, get_origin
 
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.exceptions import TypeMismatchError
 from sqlcrucible.conversion.registry import Converter, ConverterFactory
 from sqlcrucible.conversion.registry import ConverterRegistry
@@ -39,10 +40,10 @@ class NoOpConverter(Converter[Any, Any]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return types_are_non_parameterised_and_equal(source_tp, target_tp)
 
-    def convert(self, source: Any) -> Any:
+    def convert(self, source: Any, context: ConversionContext) -> Any:
         return source
 
-    def safe_convert(self, source: Any) -> Any:
+    def safe_convert(self, source: Any, context: ConversionContext) -> Any:
         if not (self._target_origin is Any or isinstance(source, self._target_origin)):
             raise TypeMismatchError(source, self._target_tp)
         return source

--- a/src/sqlcrucible/conversion/registry.py
+++ b/src/sqlcrucible/conversion/registry.py
@@ -16,6 +16,8 @@ list[CustomType] needs a converter for CustomType).
 
 from typing import Any, Protocol, TypeVar, runtime_checkable
 
+from sqlcrucible.conversion.context import ConversionContext
+
 _I = TypeVar("_I", contravariant=True)
 _O = TypeVar("_O", covariant=True)
 
@@ -34,7 +36,7 @@ class Converter(Protocol[_I, _O]):
         """
         ...
 
-    def convert(self, source: _I) -> _O:
+    def convert(self, source: _I, context: ConversionContext) -> _O:
         """Convert a value from source type to target type (fast path).
 
         This method assumes the input is valid based on static type resolution.
@@ -43,13 +45,15 @@ class Converter(Protocol[_I, _O]):
 
         Args:
             source: The value to convert.
+            context: The conversion context for the field being converted
+                (carries the resolved field type, for converters that need it).
 
         Returns:
             The converted value.
         """
         ...
 
-    def safe_convert(self, source: _I) -> _O:
+    def safe_convert(self, source: _I, context: ConversionContext) -> _O:
         """Convert a value with runtime type validation.
 
         This method validates the input at runtime and raises ConversionError
@@ -58,6 +62,7 @@ class Converter(Protocol[_I, _O]):
 
         Args:
             source: The value to convert.
+            context: The conversion context for the field being converted.
 
         Returns:
             The converted value.

--- a/src/sqlcrucible/conversion/sequences.py
+++ b/src/sqlcrucible/conversion/sequences.py
@@ -16,6 +16,7 @@ Example:
 
 from typing import Any, Sequence, get_args, get_origin
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
 from sqlcrucible._types.params import get_type_params_for_base
 
@@ -58,11 +59,11 @@ class SequenceConverter(Converter[Sequence, KnownSequenceType]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return True
 
-    def convert(self, source: Sequence) -> Any:
-        return self._target(self._inner.convert(it) for it in source)
+    def convert(self, source: Sequence, context: ConversionContext) -> Any:
+        return self._target(self._inner.convert(it, context) for it in source)
 
-    def safe_convert(self, source: Sequence) -> Any:
-        return self._target(self._inner.safe_convert(it) for it in source)
+    def safe_convert(self, source: Sequence, context: ConversionContext) -> Any:
+        return self._target(self._inner.safe_convert(it, context) for it in source)
 
 
 class SequenceConverterFactory(ConverterFactory[Sequence, KnownSequenceType]):

--- a/src/sqlcrucible/conversion/unions.py
+++ b/src/sqlcrucible/conversion/unions.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable, Sequence
 from types import UnionType
 from typing import Any, TypeVar, Union, get_args, get_origin
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.exceptions import ConversionError, NoConverterFoundError
 from sqlcrucible.conversion.noop import NoOpConverter
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
@@ -105,7 +106,7 @@ class UnionConverter(Converter[Any, Any]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return _is_union(source_tp) or _is_union(target_tp)
 
-    def convert(self, source: Any) -> Any:
+    def convert(self, source: Any, context: ConversionContext) -> Any:
         source_type = type(source)
         candidates = [
             conv
@@ -115,15 +116,15 @@ class UnionConverter(Converter[Any, Any]):
 
         for converter in candidates:
             try:
-                return converter.safe_convert(source)
+                return converter.safe_convert(source, context)
             except ConversionError:
                 continue
 
         raise NoConverterFoundError(source, self._target_tp)
 
-    def safe_convert(self, source: Any) -> Any:
+    def safe_convert(self, source: Any, context: ConversionContext) -> Any:
         # Union conversion always uses safe_convert internally
-        return self.convert(source)
+        return self.convert(source, context)
 
 
 class UnionConverterFactory(ConverterFactory[Any, Any]):

--- a/src/sqlcrucible/entity/annotations.py
+++ b/src/sqlcrucible/entity/annotations.py
@@ -8,8 +8,15 @@ from typing import Any
 
 from sqlalchemy.orm import ORMDescriptor
 
-from sqlcrucible.conversion.function import FunctionConverter
-from sqlcrucible.conversion.registry import Converter
+from sqlcrucible.conversion.context import ConversionContext
+
+__all__ = [
+    "SQLAlchemyField",
+    "ExcludeSAField",
+    "ConvertFromSAWith",
+    "ConvertToSAWith",
+    "ConversionContext",
+]
 
 
 @dataclass(frozen=True, slots=True)
@@ -49,39 +56,48 @@ class ExcludeSAField:
     value: bool = True
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, frozen=True)
 class ConvertFromSAWith:
-    """Annotation specifying custom converter from SQLAlchemy to entity.
+    """Annotation specifying a custom converter from SQLAlchemy to entity.
 
-    Use this annotation to provide a custom conversion function when loading
-    values from SQLAlchemy models into entity instances.
+    The callable receives ``(value, context)``. ``context.target_type`` is the
+    resolved entity-side field type — for a concrete specialisation of a generic
+    entity it's the specialised type on the subclass, not the ``TypeVar`` — so a
+    converter can validate against it without having to guess.
 
     Example:
         ```python
         from typing import Annotated
+        from pydantic import TypeAdapter
 
 
         class MyEntity(SQLCrucibleEntity):
             created_at: Annotated[
-                datetime, mapped_column(), ConvertFromSAWith(lambda dt: dt.astimezone(timezone.utc))
+                datetime,
+                mapped_column(),
+                ConvertFromSAWith(lambda dt, ctx: dt.astimezone(timezone.utc)),
+            ]
+            payload: Annotated[
+                SomeModel | None,
+                mapped_column(JSON),
+                ConvertFromSAWith(
+                    lambda v, ctx: (
+                        None if v is None else TypeAdapter(ctx.target_type).validate_python(v)
+                    )
+                ),
             ]
         ```
     """
 
-    fn: Callable[[Any], Any]
-
-    @property
-    def converter(self) -> Converter:
-        """Get the Converter instance for this function."""
-        return FunctionConverter(self.fn)
+    fn: Callable[[Any, ConversionContext], Any]
 
 
-@dataclass(slots=True)
+@dataclass(slots=True, frozen=True)
 class ConvertToSAWith:
-    """Annotation specifying custom converter from entity to SQLAlchemy.
+    """Annotation specifying a custom converter from entity to SQLAlchemy.
 
-    Use this annotation to provide a custom conversion function when saving
-    entity values into SQLAlchemy models.
+    The callable receives ``(value, context)``. ``context.target_type`` is the
+    resolved entity-side field type of the value being converted.
 
     Example:
         ```python
@@ -90,14 +106,11 @@ class ConvertToSAWith:
 
         class MyEntity(SQLCrucibleEntity):
             created_at: Annotated[
-                datetime, mapped_column(), ConvertToSAWith(lambda dt: dt.astimezone(timezone.utc))
+                datetime,
+                mapped_column(),
+                ConvertToSAWith(lambda dt, ctx: dt.astimezone(timezone.utc)),
             ]
         ```
     """
 
-    fn: Callable[[Any], Any]
-
-    @property
-    def converter(self) -> Converter:
-        """Get the Converter instance for this function."""
-        return FunctionConverter(self.fn)
+    fn: Callable[[Any, ConversionContext], Any]

--- a/src/sqlcrucible/entity/automodel.py
+++ b/src/sqlcrucible/entity/automodel.py
@@ -95,7 +95,7 @@ def _transparent_parameterisation_origin(
     adds_own_sa_config = bool(
         own.get("__sqlalchemy_params__")
         or own.get("__sqlalchemy_base__")
-        or own.get("__sqlcrucible_fields__")
+        or own.get("__own_sqlcrucible_fields__")
     )
 
     return origin if is_parameterisation and not adds_own_sa_config else None
@@ -115,7 +115,9 @@ def _create_automodel(source: type[SQLCrucibleEntity]) -> type[Any]:
     params = vars(source).get("__sqlalchemy_params__", {})
     base = _get_sa_base(source)
 
-    own_fields: dict[str, SQLCrucibleField] = source.__dict__.get("__sqlcrucible_fields__") or {}
+    own_fields: dict[str, SQLCrucibleField] = (
+        source.__dict__.get("__own_sqlcrucible_fields__") or {}
+    )
     field_defs = [decl for decl in own_fields.values() if not decl.excluded]
 
     # Determine which fields need type annotations based on SQLAlchemy's Mapped type.

--- a/src/sqlcrucible/entity/column_projection.py
+++ b/src/sqlcrucible/entity/column_projection.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import inspect
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter
 
 if TYPE_CHECKING:
@@ -77,6 +78,9 @@ class RelationshipProjection:
     source_name: str
     mapped_name: str
     converter: Converter
+    target_type: Any
+    """Resolved entity-side type of ``source_name`` (the converter's
+    :attr:`ConversionContext.target_type`)."""
 
 
 def classify_field_converters(
@@ -101,9 +105,13 @@ def classify_field_converters(
     specs = list(cls.__to_sa_model_converters__())
 
     column_projections = [
-        _composite_projection(spec.source_name, spec.converter, composites[spec.mapped_name])
+        _composite_projection(
+            spec.source_name, spec.converter, spec.target_type, composites[spec.mapped_name]
+        )
         if spec.mapped_name in composites
-        else _column_projection(spec.source_name, spec.converter, columns[spec.mapped_name])
+        else _column_projection(
+            spec.source_name, spec.converter, spec.target_type, columns[spec.mapped_name]
+        )
         for spec in specs
         if spec.mapped_name in composites or spec.mapped_name in columns
     ]
@@ -112,6 +120,7 @@ def classify_field_converters(
             source_name=spec.source_name,
             mapped_name=spec.mapped_name,
             converter=spec.converter,
+            target_type=spec.target_type,
         )
         for spec in specs
         if spec.mapped_name not in composites and spec.mapped_name not in columns
@@ -120,12 +129,13 @@ def classify_field_converters(
 
 
 def _column_projection(
-    source_name: str, converter: Converter, column_property: Any
+    source_name: str, converter: Converter, target_type: Any, column_property: Any
 ) -> ColumnProjection:
     column_name = column_property.columns[0].name
+    context = ConversionContext(target_type=target_type)
 
     def extract(value: Any) -> tuple[Any, ...]:
-        return (converter.convert(value),)
+        return (converter.convert(value, context),)
 
     return ColumnProjection(
         source_name=source_name,
@@ -135,17 +145,18 @@ def _column_projection(
 
 
 def _composite_projection(
-    source_name: str, converter: Converter, composite_property: Any
+    source_name: str, converter: Converter, target_type: Any, composite_property: Any
 ) -> ColumnProjection:
     # ``CompositeProperty.columns`` is empty until mapper configure-time
     # resolves them (and even then is sometimes empty); ``.props`` is
     # the ColumnProperty list whose first column is what we want.
     column_names = tuple(prop.columns[0].name for prop in composite_property.props)
+    context = ConversionContext(target_type=target_type)
 
     def extract(value: Any) -> tuple[Any, ...]:
         if value is None:
             return (None,) * len(column_names)
-        converted = converter.convert(value)
+        converted = converter.convert(value, context)
         if converted is None:
             return (None,) * len(column_names)
         return tuple(converted.__composite_values__())

--- a/src/sqlcrucible/entity/core.py
+++ b/src/sqlcrucible/entity/core.py
@@ -21,7 +21,8 @@ from sqlalchemy.orm import DeclarativeBase
 from typing_extensions import Format, TypedDict, get_annotations
 
 from sqlcrucible.conversion import default_registry
-from sqlcrucible.conversion.registry import ConverterRegistry
+from sqlcrucible.conversion.context import ConversionContext
+from sqlcrucible.conversion.registry import Converter, ConverterRegistry
 from sqlcrucible.entity.sa_conversion import (
     FromSAModelConverterFactory,
     ToSAModelConverterFactory,
@@ -34,6 +35,7 @@ from sqlcrucible.entity.column_projection import (
 )
 from sqlcrucible.entity.field_resolution import (
     FieldConverter,
+    entity_field_type,
     get_from_sa_model_converter,
     get_to_sa_model_converter,
 )
@@ -184,7 +186,7 @@ class SQLCrucibleEntity:
 
     __sqlalchemy_automodel__: ClassVar[SQLAlchemyModelType]
     __sqlalchemy_type__: ClassVar[SQLAlchemyModelType] = SQLAlchemyBase
-    __sqlcrucible_fields__: ClassVar[dict[str, SQLCrucibleField] | None] = None
+    __own_sqlcrucible_fields__: ClassVar[dict[str, SQLCrucibleField] | None] = None
     __sa_model__: SQLAlchemyModel | None = None
     __identity_map__: IdentityMap | None = None
 
@@ -209,7 +211,7 @@ class SQLCrucibleEntity:
         # (from __future__ import annotations) and Python 3.14+ lazy annotations
         # (PEP 749), returning ForwardRef for unresolvable names. canonicalise_typeform
         # wraps these in LazyCanonicalisedTypeform for deferred resolution.
-        registered = cls.__dict__.get("__sqlcrucible_fields__") or {}
+        registered = cls.__dict__.get("__own_sqlcrucible_fields__") or {}
         for key, ann in get_annotations(cls, format=Format.FORWARDREF).items():
             if key in registered:
                 continue
@@ -218,47 +220,57 @@ class SQLCrucibleEntity:
 
     @classmethod
     @cache
-    def __to_sa_model_converters__(cls) -> list[FieldConverter]:
-        own_fields: dict[str, SQLCrucibleField] = cls.__dict__.get("__sqlcrucible_fields__") or {}
-        return [
-            *[
-                converter
+    def __sqlcrucible_fields__(cls) -> dict[str, SQLCrucibleField]:
+        """Every registered field for this class — those declared on it plus
+        those inherited from base entities, bases first so iteration order is
+        stable. A field re-declared on a subclass shadows the inherited one.
+
+        The decls carry the *declared* field types (a ``TypeVar`` stays a
+        ``TypeVar``); use :func:`entity_field_type` for the type resolved in a
+        concrete subclass's context."""
+        return {
+            **{
+                name: decl
                 for base in cls.__bases__[::-1]
                 if issubclass(base, SQLCrucibleEntity)
-                for converter in base.__to_sa_model_converters__()
-            ],
-            *[
-                FieldConverter(
-                    source_name=decl.source_name,
-                    mapped_name=decl.mapped_name,
-                    converter=get_to_sa_model_converter(cls, decl),
-                )
-                for decl in own_fields.values()
-                if decl.conversion_strategy is ConversionStrategy.EAGER and not decl.excluded
-            ],
+                for name, decl in base.__sqlcrucible_fields__().items()
+            },
+            **(cls.__dict__.get("__own_sqlcrucible_fields__") or {}),
+        }
+
+    @classmethod
+    def __field_converters__(
+        cls,
+        resolve_converter: Callable[[type[SQLCrucibleEntity], SQLCrucibleField], Converter],
+    ) -> list[FieldConverter]:
+        """Build the field converters for one conversion direction over every
+        eager field that isn't excluded from the SA model. Iterating
+        :meth:`__sqlcrucible_fields__` means inherited fields are included
+        automatically. The converter is resolved against the field's declaring
+        class (where its ``Mapped[...]`` annotation lives), while ``target_type``
+        is resolved against ``cls`` — so a converter inherited onto a concrete
+        generic specialisation sees the specialised entity-side field type
+        rather than the ``TypeVar`` it was declared with."""
+        return [
+            FieldConverter(
+                source_name=decl.source_name,
+                mapped_name=decl.mapped_name,
+                converter=resolve_converter(decl.owner, decl),
+                target_type=entity_field_type(cls, decl.source_name),
+            )
+            for decl in cls.__sqlcrucible_fields__().values()
+            if decl.conversion_strategy is ConversionStrategy.EAGER and not decl.excluded
         ]
 
     @classmethod
     @cache
+    def __to_sa_model_converters__(cls) -> list[FieldConverter]:
+        return cls.__field_converters__(get_to_sa_model_converter)
+
+    @classmethod
+    @cache
     def __from_sa_model_converters__(cls) -> list[FieldConverter]:
-        own_fields: dict[str, SQLCrucibleField] = cls.__dict__.get("__sqlcrucible_fields__") or {}
-        return [
-            *[
-                converter
-                for base in cls.__bases__[::-1]
-                if issubclass(base, SQLCrucibleEntity)
-                for converter in base.__from_sa_model_converters__()
-            ],
-            *[
-                FieldConverter(
-                    source_name=decl.source_name,
-                    mapped_name=decl.mapped_name,
-                    converter=get_from_sa_model_converter(cls, decl),
-                )
-                for decl in own_fields.values()
-                if decl.conversion_strategy is ConversionStrategy.EAGER and not decl.excluded
-            ],
-        ]
+        return cls.__field_converters__(get_from_sa_model_converter)
 
     @classmethod
     def from_sa_model(cls, sa_model: Any) -> Self:
@@ -305,9 +317,11 @@ class SQLCrucibleEntity:
     def _from_sa_model(cls, sa_model: Any) -> Self:
         with _identity_map() as identity_map:
             kwargs = {
-                conversion_spec.source_name: conversion_spec.converter.convert(value)
+                conversion_spec.source_name: conversion_spec.converter.convert(
+                    getattr(sa_model, conversion_spec.mapped_name),
+                    ConversionContext(target_type=conversion_spec.target_type),
+                )
                 for conversion_spec in cls.__from_sa_model_converters__()
-                for value in (getattr(sa_model, conversion_spec.mapped_name),)
             }
 
             result = cls(**kwargs)
@@ -393,7 +407,8 @@ class SQLCrucibleEntity:
             **dict(self.to_columns()),
             **{
                 projection.mapped_name: projection.converter.convert(
-                    getattr(self, projection.source_name)
+                    getattr(self, projection.source_name),
+                    ConversionContext(target_type=projection.target_type),
                 )
                 for projection in self.__class__.__relationship_projections__()
             },
@@ -410,12 +425,13 @@ class SQLCrucibleEntity:
         """Register a field's canonical type during class creation.
 
         Used by ReadonlyFieldDescriptor.__set_name__ (DEFERRED) and
-        __init_subclass__ (EAGER) to build the master field registry.
+        __init_subclass__ (EAGER) to populate this class's own field registry;
+        :meth:`__sqlcrucible_fields__` flattens these across the MRO.
         """
-        defs = cls.__dict__.get("__sqlcrucible_fields__")
+        defs = cls.__dict__.get("__own_sqlcrucible_fields__")
         if defs is None:
             defs = {}
-            cls.__sqlcrucible_fields__ = defs
+            cls.__own_sqlcrucible_fields__ = defs
         if source_name in defs:
             logger.debug(
                 f"Multiple definitions of SQLCrucible field for {source_name} in class {cls}; will prefer the latest"
@@ -424,6 +440,7 @@ class SQLCrucibleEntity:
             source_name=source_name,
             typeform=typeform,
             conversion_strategy=conversion_strategy,
+            owner=cls,
         )
 
 

--- a/src/sqlcrucible/entity/descriptors.py
+++ b/src/sqlcrucible/entity/descriptors.py
@@ -18,7 +18,8 @@ from typing import (
 from sqlalchemy.orm import ORMDescriptor
 
 from sqlcrucible.conversion.caching import _identity_map
-from sqlcrucible.entity.field_resolution import get_from_sa_model_converter
+from sqlcrucible.conversion.context import ConversionContext
+from sqlcrucible.entity.field_resolution import entity_field_type, get_from_sa_model_converter
 from sqlcrucible.conversion.registry import Converter
 from sqlcrucible.entity.annotations import SQLAlchemyField
 from sqlcrucible.entity.field_definitions import (
@@ -69,8 +70,16 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
         self._tp = tp
         self._descriptor = descriptor
         self._sa_field = sa_field
-        self._converter: Converter[Any, _T] | None = None
-        self._sa_field_info: SQLCrucibleField | None = None
+        # (field_info, from-SA converter, conversion context) per resolving
+        # entity class. Keyed by the *accessing* class rather than cached as a
+        # single value because one descriptor object is shared by every
+        # subclass of the class it's declared on — and on a concrete generic
+        # specialisation the converter/context must reflect the specialised
+        # field type, not the ``TypeVar``.
+        self._loaders: dict[
+            type[SQLCrucibleEntity],
+            tuple[SQLCrucibleField, Converter[Any, Any], ConversionContext],
+        ] = {}
         self._name: str | None = None
         self._owner: type[_O] | None = None
 
@@ -124,24 +133,36 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
 
     @property
     def sa_field_info(self) -> SQLCrucibleField:
-        """Get the field definition for this descriptor.
-
-        Returns:
-            The SQLCrucibleField with resolved types
+        """The field definition registered for this descriptor (carrying the
+        *declared* type — a ``TypeVar`` stays a ``TypeVar``).
 
         Raises:
             RuntimeError: If accessed before the descriptor is assigned to a class
         """
-        if self._sa_field_info is None:
-            if self._name is None or self._owner is None:
-                raise RuntimeError(
-                    "Attempted to construct SQLAlchemyFieldInfo on `readonly_field` descriptor before descriptor is assigned to a field!"
-                )
-            fields: dict[str, SQLCrucibleField] = (
-                self._owner.__dict__.get("__sqlcrucible_fields__") or {}
+        if self._name is None or self._owner is None:
+            raise RuntimeError(
+                "Attempted to access sa_field_info on a `readonly_field` descriptor "
+                "before it was assigned to a class attribute!"
             )
-            self._sa_field_info = fields[self._name]
-        return self._sa_field_info
+        return (self._owner.__dict__.get("__own_sqlcrucible_fields__") or {})[self._name]
+
+    def _loader(
+        self, owner: type[SQLCrucibleEntity]
+    ) -> tuple[SQLCrucibleField, Converter[Any, Any], ConversionContext]:
+        loader = self._loaders.get(owner)
+        if loader is None:
+            if self._name is None:
+                raise RuntimeError(
+                    "Attempted to load a `readonly_field` before it was assigned to a class attribute!"
+                )
+            field_info = owner.__sqlcrucible_fields__()[self._name]
+            loader = (
+                field_info,
+                get_from_sa_model_converter(field_info.owner, field_info),
+                ConversionContext(target_type=entity_field_type(owner, self._name)),
+            )
+            self._loaders[owner] = loader
+        return loader
 
     @overload
     def __get__(self, instance: None, owner: type, /) -> Self: ...
@@ -177,12 +198,10 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
         if cache is not None and self._name in cache:
             return cache[self._name]
 
-        field_info = self.sa_field_info
         resolved_owner = cast(
             type["SQLCrucibleEntity"], owner if owner is not None else type(instance)
         )
-        if self._converter is None:
-            self._converter = get_from_sa_model_converter(resolved_owner, field_info)
+        field_info, converter, context = self._loader(resolved_owner)
 
         model = instance.__sa_model__
         if model is None:
@@ -195,7 +214,7 @@ class ReadonlyFieldDescriptor(property, Generic[_T, _O]):
             )
 
         with _identity_map(instance.__identity_map__):
-            result = self._converter.convert(getattr(model, field_info.mapped_name))
+            result = converter.convert(getattr(model, field_info.mapped_name), context)
 
         instance.__dict__.setdefault("__readonly_cache__", {})[self._name] = result
         return result

--- a/src/sqlcrucible/entity/field_definitions.py
+++ b/src/sqlcrucible/entity/field_definitions.py
@@ -14,6 +14,7 @@ from typing import Annotated, Any, ClassVar, get_args, get_origin, ForwardRef
 import sqlalchemy.orm
 from sqlalchemy.orm import ORMDescriptor
 
+from sqlcrucible.conversion.function import FunctionConverter
 from sqlcrucible.conversion.registry import Converter
 from sqlcrucible.entity.annotations import (
     ConvertFromSAWith,
@@ -74,9 +75,9 @@ def _extract_annotation_metadata(annotations: tuple[Any, ...]) -> AnnotationMeta
             # in annotations become class attributes on the SA model
             fields.append(SQLAlchemyField(attr=arg))
         elif isinstance(arg, ConvertFromSAWith):
-            from_sa_converter = arg.converter
+            from_sa_converter = FunctionConverter(arg.fn)
         elif isinstance(arg, ConvertToSAWith):
-            to_sa_converter = arg.converter
+            to_sa_converter = FunctionConverter(arg.fn)
         elif isinstance(arg, ExcludeSAField):
             should_exclude = arg.value
         else:
@@ -237,6 +238,12 @@ class SQLCrucibleField:
     source_name: str
     typeform: CanonicalisedTypeform
     conversion_strategy: ConversionStrategy
+    owner: Any
+    """The entity class that declared this field. Converter resolution uses it
+    (not the accessing subclass) so the SA-side type is read from the automodel
+    where the field's ``Mapped[...]`` annotation actually lives — which matters
+    for generic fields, whose annotation carries the (unsubstituted) ``TypeVar``
+    on the declaring class's automodel only."""
 
     @cached_property
     def _resolved(self) -> ConcreteCanonicalisedTypeform:

--- a/src/sqlcrucible/entity/field_resolution.py
+++ b/src/sqlcrucible/entity/field_resolution.py
@@ -19,6 +19,7 @@ from typing_extensions import get_annotations, Format
 from sqlcrucible.conversion.registry import Converter
 from sqlcrucible._types.annotations import unwrap
 from sqlcrucible._types.forward_refs import evaluate_forward_refs
+from sqlcrucible._types.params import get_type_params_for_base
 
 if TYPE_CHECKING:
     from sqlcrucible.entity.field_definitions import SQLCrucibleField
@@ -34,6 +35,55 @@ class FieldConverter(Generic[_T, _S]):
     source_name: str
     mapped_name: str
     converter: Converter[_S, _T]
+    target_type: Any
+    """The resolved entity-side type of ``source_name`` — passed to the
+    converter as :attr:`ConversionContext.target_type`. Carried per
+    :class:`FieldConverter` (rather than baked into the converter) so an
+    inherited converter on a concrete generic specialisation still sees the
+    specialised type."""
+
+
+def _substitute_type_params(tp: Any, substitution: dict[Any, Any]) -> Any:
+    """Substitute type variables in ``tp`` using a ``TypeVar -> type`` map.
+
+    Bare type variables are looked up directly; parameterised forms
+    (``list[T]``, ``T | None``, ``Annotated[list[T], ...]``, ``dict[K, V]``, …)
+    are re-subscripted on their free parameters — every generic-alias form,
+    including ``types.UnionType``, supports that. Anything with no free
+    parameters is returned unchanged. Parameters absent from ``substitution``
+    are left in place (so partial specialisations stay partial)."""
+    if isinstance(tp, TypeVar):
+        return substitution.get(tp, tp)
+    free_params: tuple[Any, ...] = getattr(tp, "__parameters__", ())
+    if not free_params:
+        return tp
+    resolved = [substitution.get(param, param) for param in free_params]
+    return tp[tuple(resolved)] if len(resolved) > 1 else tp[resolved[0]]
+
+
+def entity_field_type(cls: type[SQLCrucibleEntity], source_name: str) -> Any:
+    """The resolved entity-side type of ``source_name`` on ``cls``.
+
+    For a Pydantic entity this is the substituted ``model_fields`` annotation.
+    For any other entity it's the type the field was declared with, with any
+    type variables bound by ``cls``'s generic specialisation substituted in —
+    so a concrete specialisation of a generic entity reports the specialised
+    type rather than the declared ``TypeVar``. Returns ``None`` if the field
+    isn't registered."""
+    model_fields = getattr(cls, "model_fields", None)
+    if model_fields is not None and source_name in model_fields:
+        return model_fields[source_name].annotation
+    decl = cls.__sqlcrucible_fields__().get(source_name)
+    if decl is None:
+        return None
+    owner_params = getattr(decl.owner, "__parameters__", ())
+    if not owner_params or decl.owner is cls:
+        return decl.source_tp
+    try:
+        owner_args = get_type_params_for_base(cls, decl.owner)
+    except TypeError:
+        return decl.source_tp
+    return _substitute_type_params(decl.source_tp, dict(zip(owner_params, owner_args, strict=True)))
 
 
 def get_from_sa_model_converter(cls: type[_E], field_def: SQLCrucibleField) -> Converter:
@@ -48,7 +98,7 @@ def get_from_sa_model_converter(cls: type[_E], field_def: SQLCrucibleField) -> C
             f"No converter found for field '{field_def.source_name}' in {cls.__name__}: "
             f"cannot convert from SQLAlchemy type {mapped_tp} to entity type {source_tp}.\n"
             f"Hint: Add a custom converter using ConvertFromSAWith:\n"
-            f"    {field_def.source_name}: Annotated[{source_tp}, ..., ConvertFromSAWith(lambda x: ...)]"
+            f"    {field_def.source_name}: Annotated[{source_tp}, ..., ConvertFromSAWith(lambda x, ctx: ...)]"
         )
     return result
 
@@ -65,7 +115,7 @@ def get_to_sa_model_converter(cls: type[_E], field_def: SQLCrucibleField) -> Con
             f"No converter found for field '{field_def.source_name}' in {cls.__name__}: "
             f"cannot convert from entity type {source_tp} to SQLAlchemy type {mapped_tp}.\n"
             f"Hint: Add a custom converter using ConvertToSAWith:\n"
-            f"    {field_def.source_name}: Annotated[{source_tp}, ..., ConvertToSAWith(lambda x: ...)]"
+            f"    {field_def.source_name}: Annotated[{source_tp}, ..., ConvertToSAWith(lambda x, ctx: ...)]"
         )
     return result
 

--- a/src/sqlcrucible/entity/sa_conversion.py
+++ b/src/sqlcrucible/entity/sa_conversion.py
@@ -1,6 +1,7 @@
 from typing import Any, TypeVar, TYPE_CHECKING
 
 from sqlcrucible._types.annotations import unwrap, types_are_non_parameterised_and_equal
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterFactory, ConverterRegistry
 
 if TYPE_CHECKING:
@@ -22,11 +23,11 @@ class ToSAModelConverter(Converter[_E, Any]):
         )
         return source_matches_my_entity and target_matches_source_sa_type
 
-    def convert(self, source: _E) -> Any:
+    def convert(self, source: _E, context: ConversionContext) -> Any:
         return source.to_sa_model()
 
-    def safe_convert(self, source: _E) -> Any:
-        return self.convert(source)
+    def safe_convert(self, source: _E, context: ConversionContext) -> Any:
+        return self.convert(source, context)
 
 
 class ToSAModelConverterFactory(ConverterFactory[Any, Any]):
@@ -60,11 +61,11 @@ class FromSAModelConverter(Converter[_E, Any]):
         )
         return target_matches_my_entity and source_matches_target_sa_type
 
-    def convert(self, source: _E) -> Any:
+    def convert(self, source: _E, context: ConversionContext) -> Any:
         return self._sqlcrucible_entity.from_sa_model(source)
 
-    def safe_convert(self, source: _E) -> Any:
-        return self.convert(source)
+    def safe_convert(self, source: _E, context: ConversionContext) -> Any:
+        return self.convert(source, context)
 
 
 class FromSAModelConverterFactory(ConverterFactory[Any, Any]):

--- a/tests/conversion/conftest.py
+++ b/tests/conversion/conftest.py
@@ -4,7 +4,12 @@ from typing import Any
 import pytest
 
 from sqlcrucible.conversion import default_registry
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterRegistry
+
+#: A throwaway context for converter unit tests — the converters under test
+#: here don't consult ``target_type``, so its value is irrelevant.
+ANY_CONTEXT = ConversionContext(target_type=Any)
 
 
 @dataclass(frozen=True)
@@ -23,11 +28,11 @@ class SourceToTargetConverter(Converter[SourceItem, TargetItem]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return source_tp is SourceItem and target_tp is TargetItem
 
-    def convert(self, source: SourceItem) -> TargetItem:
+    def convert(self, source: SourceItem, context: ConversionContext) -> TargetItem:
         return TargetItem(value=source.value * 2)
 
-    def safe_convert(self, source: SourceItem) -> TargetItem:
-        return self.convert(source)
+    def safe_convert(self, source: SourceItem, context: ConversionContext) -> TargetItem:
+        return self.convert(source, context)
 
 
 class TargetToSourceConverter(Converter[TargetItem, SourceItem]):
@@ -36,11 +41,11 @@ class TargetToSourceConverter(Converter[TargetItem, SourceItem]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return source_tp is TargetItem and target_tp is SourceItem
 
-    def convert(self, source: TargetItem) -> SourceItem:
+    def convert(self, source: TargetItem, context: ConversionContext) -> SourceItem:
         return SourceItem(value=source.value // 2)
 
-    def safe_convert(self, source: TargetItem) -> SourceItem:
-        return self.convert(source)
+    def safe_convert(self, source: TargetItem, context: ConversionContext) -> SourceItem:
+        return self.convert(source, context)
 
 
 @pytest.fixture

--- a/tests/conversion/test_caching.py
+++ b/tests/conversion/test_caching.py
@@ -12,9 +12,12 @@ import pytest
 
 from sqlcrucible.conversion import default_registry
 from sqlcrucible.conversion.caching import CachingConverter, _identity_map
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.dicts import DictConverter, DictInfo
 from sqlcrucible.conversion.registry import Converter
 from sqlcrucible.conversion.sequences import SequenceConverter
+
+from tests.conversion.conftest import ANY_CONTEXT
 
 
 @dataclass
@@ -36,11 +39,11 @@ class DoublingConverter(Converter[Source, Target]):
     def matches(self, source_tp: Any, target_tp: Any) -> bool:
         return True
 
-    def convert(self, source: Source) -> Target:
+    def convert(self, source: Source, context: ConversionContext) -> Target:
         self.call_count += 1
         return Target(value=source.value * 2)
 
-    def safe_convert(self, source: Source) -> Target:
+    def safe_convert(self, source: Source, context: ConversionContext) -> Target:
         self.call_count += 1
         return Target(value=source.value * 2)
 
@@ -54,7 +57,7 @@ def test_cache_hit_returns_cached_result() -> None:
 
     with _identity_map() as identity_map:
         identity_map[id(source)] = cached
-        result = converter.convert(source)
+        result = converter.convert(source, ANY_CONTEXT)
 
     assert result is cached
     assert inner.call_count == 0
@@ -67,7 +70,7 @@ def test_cache_miss_delegates_to_inner() -> None:
     source = Source(5)
 
     with _identity_map():
-        result = converter.convert(source)
+        result = converter.convert(source, ANY_CONTEXT)
 
     assert result == Target(10)
     assert inner.call_count == 1
@@ -78,7 +81,7 @@ def test_no_identity_map_delegates_to_inner() -> None:
     inner = DoublingConverter()
     converter = CachingConverter(inner)
 
-    result = converter.convert(Source(3))
+    result = converter.convert(Source(3), ANY_CONTEXT)
 
     assert result == Target(6)
     assert inner.call_count == 1
@@ -93,7 +96,7 @@ def test_safe_convert_uses_cache() -> None:
 
     with _identity_map() as identity_map:
         identity_map[id(source)] = cached
-        result = converter.safe_convert(source)
+        result = converter.safe_convert(source, ANY_CONTEXT)
 
     assert result is cached
     assert inner.call_count == 0
@@ -110,7 +113,7 @@ def test_cache_hit_inside_sequence() -> None:
 
     with _identity_map() as identity_map:
         identity_map[id(cached_source)] = cached_target
-        result = seq.convert([cached_source, uncached_source])
+        result = seq.convert([cached_source, uncached_source], ANY_CONTEXT)
 
     assert result[0] is cached_target
     assert result[1] == Target(4)
@@ -133,7 +136,7 @@ def test_cache_hit_inside_dict() -> None:
 
     with _identity_map() as identity_map:
         identity_map[id(cached_source)] = cached_target
-        result = dict_conv.convert({"a": cached_source, "b": uncached_source})
+        result = dict_conv.convert({"a": cached_source, "b": uncached_source}, ANY_CONTEXT)
 
     assert result["a"] is cached_target
     assert result["b"] == Target(4)
@@ -153,8 +156,8 @@ def test_shared_source_across_entity_and_sequence() -> None:
 
     with _identity_map() as identity_map:
         identity_map[id(shared)] = cached_shared
-        direct = caching.convert(shared)
-        from_list = seq.convert([shared, other])
+        direct = caching.convert(shared, ANY_CONTEXT)
+        from_list = seq.convert([shared, other], ANY_CONTEXT)
 
     assert direct is cached_shared
     assert from_list[0] is cached_shared
@@ -189,8 +192,8 @@ def test_default_registry_sequence_converter_caches_by_identity() -> None:
     source = [1, 2, 3]
 
     with _identity_map():
-        first = converter.convert(source)
-        second = converter.convert(source)
+        first = converter.convert(source, ANY_CONTEXT)
+        second = converter.convert(source, ANY_CONTEXT)
 
     assert first is second
 
@@ -203,7 +206,7 @@ def test_default_registry_dict_converter_caches_by_identity() -> None:
     source = {"a": 1, "b": 2}
 
     with _identity_map():
-        first = converter.convert(source)
-        second = converter.convert(source)
+        first = converter.convert(source, ANY_CONTEXT)
+        second = converter.convert(source, ANY_CONTEXT)
 
     assert first is second

--- a/tests/conversion/test_caching_properties.py
+++ b/tests/conversion/test_caching_properties.py
@@ -12,6 +12,7 @@ from hypothesis import given
 from sqlcrucible.conversion.caching import CachingConverter, _identity_map
 from sqlcrucible.conversion.registry import Converter
 
+from tests.conversion.conftest import ANY_CONTEXT
 from tests.strategies import Source, Target, shared_object_list
 
 
@@ -21,8 +22,8 @@ def _make_doubling_converter() -> tuple[CachingConverter[Source, Target], MagicM
     Returns the caching converter and the mock so callers can inspect calls.
     """
     inner = MagicMock(spec=Converter)
-    inner.convert.side_effect = lambda src: Target(value=src.value * 2)
-    inner.safe_convert.side_effect = lambda src: Target(value=src.value * 2)
+    inner.convert.side_effect = lambda src, ctx: Target(value=src.value * 2)
+    inner.safe_convert.side_effect = lambda src, ctx: Target(value=src.value * 2)
     return CachingConverter(inner), inner
 
 
@@ -32,7 +33,7 @@ def test_same_object_returns_identical_result(data):
     converter, _inner = _make_doubling_converter()
 
     with _identity_map():
-        results = [converter.convert(src) for src in reference_list]
+        results = [converter.convert(src, ANY_CONTEXT) for src in reference_list]
 
     seen: dict[int, Target] = {}
     for src, result in zip(reference_list, results, strict=True):
@@ -49,7 +50,7 @@ def test_inner_converter_called_once_per_unique_object(data):
 
     with _identity_map():
         for src in reference_list:
-            converter.convert(src)
+            converter.convert(src, ANY_CONTEXT)
 
     unique_source_ids = {id(src) for src in reference_list}
     assert inner.convert.call_count == len(unique_source_ids)
@@ -61,7 +62,7 @@ def test_safe_convert_same_identity_invariant(data):
     converter, _inner = _make_doubling_converter()
 
     with _identity_map():
-        results = [converter.safe_convert(src) for src in reference_list]
+        results = [converter.safe_convert(src, ANY_CONTEXT) for src in reference_list]
 
     seen: dict[int, Target] = {}
     for src, result in zip(reference_list, results, strict=True):
@@ -77,13 +78,13 @@ def test_separate_contexts_are_isolated(data):
     converter, inner = _make_doubling_converter()
 
     with _identity_map():
-        first_results = [converter.convert(src) for src in reference_list]
+        first_results = [converter.convert(src, ANY_CONTEXT) for src in reference_list]
 
     inner.reset_mock()
-    inner.convert.side_effect = lambda src: Target(value=src.value * 2)
+    inner.convert.side_effect = lambda src, ctx: Target(value=src.value * 2)
 
     with _identity_map():
-        second_results = [converter.convert(src) for src in reference_list]
+        second_results = [converter.convert(src, ANY_CONTEXT) for src in reference_list]
 
     for first, second in zip(first_results, second_results, strict=True):
         assert first is not second
@@ -98,7 +99,7 @@ def test_conversion_results_are_correct(data):
     converter, _inner = _make_doubling_converter()
 
     with _identity_map():
-        results = [converter.convert(src) for src in reference_list]
+        results = [converter.convert(src, ANY_CONTEXT) for src in reference_list]
 
     for src, result in zip(reference_list, results, strict=True):
         assert result.value == src.value * 2

--- a/tests/conversion/test_dicts.py
+++ b/tests/conversion/test_dicts.py
@@ -6,7 +6,7 @@ import pytest
 
 from sqlcrucible.conversion.registry import ConverterRegistry
 from sqlcrucible.conversion.dicts import DictConverterFactory, DictInfo
-from tests.conversion.conftest import SourceItem, TargetItem
+from tests.conversion.conftest import ANY_CONTEXT, SourceItem, TargetItem
 
 
 class PersonDict(TypedDict):
@@ -99,7 +99,7 @@ def test_dict_to_dict_converts_correctly(
 ) -> None:
     conv = registry.resolve(source_tp, target_tp)
     assert conv is not None
-    actual_output = conv.convert(input_value)
+    actual_output = conv.convert(input_value, ANY_CONTEXT)
     assert actual_output == expected_output
 
 
@@ -108,7 +108,7 @@ def test_dict_to_dict_creates_new_reference(registry: ConverterRegistry) -> None
     conv = registry.resolve(dict[str, int], dict[str, int])
     assert conv is not None
     original = {"a": 1, "b": 2}
-    result = conv.convert(original)
+    result = conv.convert(original, ANY_CONTEXT)
     assert result == original
     assert result is not original
 
@@ -137,14 +137,14 @@ def test_unparameterized_dict_to_nested_typeddict_returns_none(
 def test_typeddict_to_plain_dict(registry: ConverterRegistry):
     converter = registry.resolve(PersonDict, dict)
     assert converter is not None
-    result = converter.convert({"name": "Alice", "age": 30})
+    result = converter.convert({"name": "Alice", "age": 30}, ANY_CONTEXT)
     assert result == {"name": "Alice", "age": 30}
 
 
 def test_typeddict_to_parameterized_dict(registry: ConverterRegistry):
     converter = registry.resolve(PersonDict, dict[str, Any])
     assert converter is not None
-    result = converter.convert({"name": "Alice", "age": 30})
+    result = converter.convert({"name": "Alice", "age": 30}, ANY_CONTEXT)
     assert result == {"name": "Alice", "age": 30}
 
 
@@ -153,7 +153,7 @@ def test_typeddict_to_dict_creates_new_reference(registry: ConverterRegistry):
     converter = registry.resolve(PersonDict, dict)
     assert converter is not None
     original: PersonDict = {"name": "Alice", "age": 30}
-    result = converter.convert(original)
+    result = converter.convert(original, ANY_CONTEXT)
     assert result == original
     assert result is not original
 
@@ -162,7 +162,7 @@ def test_typeddict_to_same_typeddict_creates_copy(registry: ConverterRegistry):
     converter = registry.resolve(PersonDict, PersonDict)
     assert converter is not None
     original: PersonDict = {"name": "Alice", "age": 30}
-    result = converter.convert(original)
+    result = converter.convert(original, ANY_CONTEXT)
     assert result == original
     assert result is not original
 
@@ -170,7 +170,7 @@ def test_typeddict_to_same_typeddict_creates_copy(registry: ConverterRegistry):
 def test_typeddict_to_compatible_typeddict(registry: ConverterRegistry):
     converter = registry.resolve(PersonDict, PartialDict)
     assert converter is not None
-    result = converter.convert({"name": "Alice", "age": 30})
+    result = converter.convert({"name": "Alice", "age": 30}, ANY_CONTEXT)
     assert result == {"name": "Alice", "age": 30}
 
 
@@ -178,14 +178,14 @@ def test_partial_typeddict_to_total_missing_required(registry: ConverterRegistry
     converter = registry.resolve(PartialDict, PersonDict)
     assert converter is not None
     with pytest.raises(TypeError) as exc_info:
-        converter.convert({"name": "Alice"})
+        converter.convert({"name": "Alice"}, ANY_CONTEXT)
     assert "age" in str(exc_info.value)
 
 
 def test_partial_typeddict_to_total_with_all_fields(registry: ConverterRegistry):
     converter = registry.resolve(PartialDict, PersonDict)
     assert converter is not None
-    result = converter.convert({"name": "Alice", "age": 30})
+    result = converter.convert({"name": "Alice", "age": 30}, ANY_CONTEXT)
     assert result == {"name": "Alice", "age": 30}
 
 

--- a/tests/conversion/test_literals.py
+++ b/tests/conversion/test_literals.py
@@ -6,6 +6,8 @@ from sqlcrucible.conversion.exceptions import TypeMismatchError
 from sqlcrucible.conversion.literals import LiteralConverter, LiteralConverterFactory
 from sqlcrucible.conversion.registry import ConverterRegistry
 
+from tests.conversion.conftest import ANY_CONTEXT
+
 
 @pytest.mark.parametrize(
     ("source_tp", "target_tp"),
@@ -68,7 +70,7 @@ def test_literal_converter_factory_does_not_match_non_literal_types(source_tp, t
 )
 def test_literal_converter_returns_value_when_valid(value, target_tp):
     converter = LiteralConverter(target_tp)
-    assert converter.convert(value) is value
+    assert converter.convert(value, ANY_CONTEXT) is value
 
 
 @pytest.mark.parametrize(
@@ -84,7 +86,7 @@ def test_literal_converter_returns_value_when_valid(value, target_tp):
 def test_literal_converter_safe_convert_raises_error_when_value_not_in_literal(value, target_tp):
     converter = LiteralConverter(target_tp)
     with pytest.raises(TypeMismatchError) as exc_info:
-        converter.safe_convert(value)
+        converter.safe_convert(value, ANY_CONTEXT)
     assert exc_info.value.source is value
     assert exc_info.value.target_type is target_tp
 
@@ -92,7 +94,7 @@ def test_literal_converter_safe_convert_raises_error_when_value_not_in_literal(v
 def test_literal_converter_error_message_contains_allowed_values():
     converter = LiteralConverter(Literal["a", "b", "c"])
     with pytest.raises(TypeMismatchError) as exc_info:
-        converter.safe_convert("x")
+        converter.safe_convert("x", ANY_CONTEXT)
     assert "x" in str(exc_info.value)
     assert "'a'" in str(exc_info.value)
     assert "'b'" in str(exc_info.value)
@@ -104,7 +106,7 @@ def test_literal_converter_via_registry(registry: ConverterRegistry):
     target_tp = Literal["a", "b"]
     converter = registry.resolve(source_tp, target_tp)
     assert converter is not None
-    assert converter.convert("a") == "a"
+    assert converter.convert("a", ANY_CONTEXT) == "a"
 
 
 def test_literal_converter_via_registry_returns_none_when_not_subset(registry: ConverterRegistry):

--- a/tests/conversion/test_literals_properties.py
+++ b/tests/conversion/test_literals_properties.py
@@ -10,6 +10,8 @@ from hypothesis import given
 from sqlcrucible.conversion.exceptions import TypeMismatchError
 from sqlcrucible.conversion.literals import LiteralConverter, LiteralConverterFactory
 
+from tests.conversion.conftest import ANY_CONTEXT
+
 from tests.strategies import (
     literal_non_subset_pair,
     literal_subset_pair,
@@ -55,7 +57,7 @@ def test_convert_is_identity(data):
 
     converter = LiteralConverter(target_tp)
     for value in source_values:
-        assert converter.convert(value) is value
+        assert converter.convert(value, ANY_CONTEXT) is value
 
 
 @given(data=literal_subset_pair())
@@ -65,7 +67,7 @@ def test_safe_convert_accepts_subset_values(data):
 
     converter = LiteralConverter(target_tp)
     for value in source_values:
-        assert converter.safe_convert(value) is value
+        assert converter.safe_convert(value, ANY_CONTEXT) is value
 
 
 @given(data=literal_non_subset_pair())
@@ -77,4 +79,4 @@ def test_safe_convert_rejects_values_not_in_target(data):
     converter = LiteralConverter(target_tp)
     for value in extra_values:
         with pytest.raises(TypeMismatchError):
-            converter.safe_convert(value)
+            converter.safe_convert(value, ANY_CONTEXT)

--- a/tests/conversion/test_noop.py
+++ b/tests/conversion/test_noop.py
@@ -4,6 +4,8 @@ from sqlcrucible.conversion.exceptions import TypeMismatchError
 from sqlcrucible.conversion.noop import NoOpConverter, NoOpConverterFactory
 from sqlcrucible.conversion.registry import ConverterRegistry
 
+from tests.conversion.conftest import ANY_CONTEXT
+
 
 @pytest.mark.parametrize(
     ("source_tp", "target_tp"),
@@ -50,7 +52,7 @@ def test_noop_converter_does_not_match_different_or_generic_types(source_tp, tar
 def test_noop_converter_returns_same_object(registry: ConverterRegistry, tp, value) -> None:
     conv = NoOpConverterFactory().converter(tp, tp, registry)
     assert conv is not None
-    assert conv.convert(value) is value
+    assert conv.convert(value, ANY_CONTEXT) is value
 
 
 @pytest.mark.parametrize(
@@ -68,7 +70,7 @@ def test_noop_converter_returns_same_object(registry: ConverterRegistry, tp, val
 def test_noop_converter_safe_convert_raises_typeerror_on_value_not_matching_type(tp, value) -> None:
     conv = NoOpConverter(tp)
     with pytest.raises(TypeMismatchError) as exc_info:
-        conv.safe_convert(value)
+        conv.safe_convert(value, ANY_CONTEXT)
     # Verify the exception contains useful context
     assert exc_info.value.source is value
     assert exc_info.value.target_type is tp

--- a/tests/conversion/test_registry.py
+++ b/tests/conversion/test_registry.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+from sqlcrucible.conversion.context import ConversionContext
 from sqlcrucible.conversion.registry import Converter, ConverterRegistry
+
+from tests.conversion.conftest import ANY_CONTEXT
 
 
 def test_registry_returns_none_when_no_match() -> None:
@@ -16,11 +19,11 @@ def test_registry_returns_first_matching_converter() -> None:
         def matches(self, source_tp: Any, target_tp: Any) -> bool:
             return True
 
-        def convert(self, source: Any) -> Any:
+        def convert(self, source: Any, context: ConversionContext) -> Any:
             return self._result
 
-        def safe_convert(self, source: Any) -> Any:
-            return self.convert(source)
+        def safe_convert(self, source: Any, context: ConversionContext) -> Any:
+            return self.convert(source, context)
 
     first_converter = AlwaysMatchConverter("first")
     second_converter = AlwaysMatchConverter("second")
@@ -30,4 +33,4 @@ def test_registry_returns_first_matching_converter() -> None:
     conv = registry.resolve(int, str)
     assert conv is not None
     assert conv is first_converter
-    assert conv.convert(42) == "first"
+    assert conv.convert(42, ANY_CONTEXT) == "first"

--- a/tests/conversion/test_sequences.py
+++ b/tests/conversion/test_sequences.py
@@ -1,4 +1,4 @@
-from tests.conversion.conftest import TargetItem, SourceItem
+from tests.conversion.conftest import ANY_CONTEXT, TargetItem, SourceItem
 
 import pytest
 
@@ -59,5 +59,5 @@ def test_sequence_conversion_produces_correct_type(
 ):
     conv = registry.resolve(source_tp, target_tp)
     assert conv is not None
-    actual_output = conv.convert(input_value)
+    actual_output = conv.convert(input_value, ANY_CONTEXT)
     assert actual_output == expected_output

--- a/tests/conversion/test_unions.py
+++ b/tests/conversion/test_unions.py
@@ -1,4 +1,4 @@
-from tests.conversion.conftest import SourceItem, TargetItem
+from tests.conversion.conftest import ANY_CONTEXT, SourceItem, TargetItem
 
 from typing import Any, cast
 
@@ -107,7 +107,7 @@ def test_nested_conversion_applied_in_union(
 ):
     conv = registry.resolve(source_tp, target_tp)
     assert conv is not None
-    actual_output = conv.convert(input_value)
+    actual_output = conv.convert(input_value, ANY_CONTEXT)
     assert actual_output == expected_output
 
 

--- a/tests/conversion/test_unwrap.py
+++ b/tests/conversion/test_unwrap.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Mapped
 
 from sqlcrucible.conversion.registry import ConverterRegistry
 from sqlcrucible.conversion.unwrap import AnnotatedUnwrappingFactory
-from tests.conversion.conftest import SourceItem, TargetItem
+from tests.conversion.conftest import ANY_CONTEXT, SourceItem, TargetItem
 
 
 @pytest.mark.parametrize(
@@ -53,7 +53,7 @@ def test_delegates_to_registry_with_unwrapped_types(registry: ConverterRegistry)
         registry,
     )
     assert converter is not None
-    result = converter.convert(SourceItem(1))
+    result = converter.convert(SourceItem(1), ANY_CONTEXT)
     assert result == TargetItem(2)
 
 
@@ -61,7 +61,7 @@ def test_registry_resolves_annotated_source_via_unwrapping(registry: ConverterRe
     unwrapping_registry = ConverterRegistry(AnnotatedUnwrappingFactory(), *registry)
     conv = unwrapping_registry.resolve(Annotated[SourceItem, "marker"], TargetItem)
     assert conv is not None
-    assert conv.convert(SourceItem(3)) == TargetItem(6)
+    assert conv.convert(SourceItem(3), ANY_CONTEXT) == TargetItem(6)
 
 
 def test_registry_resolves_annotated_list_via_unwrapping(registry: ConverterRegistry):
@@ -71,11 +71,14 @@ def test_registry_resolves_annotated_list_via_unwrapping(registry: ConverterRegi
         list[TargetItem],
     )
     assert conv is not None
-    assert conv.convert([SourceItem(1), SourceItem(2)]) == [TargetItem(2), TargetItem(4)]
+    assert conv.convert([SourceItem(1), SourceItem(2)], ANY_CONTEXT) == [
+        TargetItem(2),
+        TargetItem(4),
+    ]
 
 
 def test_registry_resolves_mapped_source_via_unwrapping(registry: ConverterRegistry):
     unwrapping_registry = ConverterRegistry(AnnotatedUnwrappingFactory(), *registry)
     conv = unwrapping_registry.resolve(Mapped[SourceItem], TargetItem)
     assert conv is not None
-    assert conv.convert(SourceItem(5)) == TargetItem(10)
+    assert conv.convert(SourceItem(5), ANY_CONTEXT) == TargetItem(10)

--- a/tests/entity/test_attrs_entity.py
+++ b/tests/entity/test_attrs_entity.py
@@ -39,8 +39,8 @@ class Track(BaseTestEntity):
         timedelta,
         mapped_column(),
         SQLAlchemyField(name="length_seconds", tp=int),
-        ConvertToSAWith(lambda td: td.total_seconds()),
-        ConvertFromSAWith(lambda it: timedelta(seconds=it)),
+        ConvertToSAWith(lambda td, ctx: td.total_seconds()),
+        ConvertFromSAWith(lambda it, ctx: timedelta(seconds=it)),
     ] = field()
     notes: Annotated[str | None, mapped_column(nullable=True)] = field(default=None)
 

--- a/tests/entity/test_conversion_context.py
+++ b/tests/entity/test_conversion_context.py
@@ -1,0 +1,171 @@
+"""``ConvertFromSAWith`` / ``ConvertToSAWith`` callables receive a
+:class:`ConversionContext` whose ``target_type`` is the *resolved* entity-side
+field type — so on a concrete specialisation of a generic entity it's the
+specialised type, not the declared ``TypeVar``. That holds whether the entity
+is a Pydantic model (resolved via ``model_fields``) or any other backend
+(resolved by substituting the type variables bound up the MRO), which is what
+lets e.g. a JSON column be re-validated against the right per-subclass type.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Annotated, Any, Generic, TypeVar
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import BaseModel, Field, TypeAdapter
+from sqlalchemy import JSON, Integer, MetaData, String
+from sqlalchemy.orm import mapped_column
+
+from sqlcrucible import ConversionContext, ConvertFromSAWith, ConvertToSAWith, ExcludeSAField
+from sqlcrucible.entity.core import SQLCrucibleBaseModel, SQLCrucibleEntity
+from sqlcrucible.entity.field_resolution import entity_field_type
+
+D = TypeVar("D", bound=BaseModel)
+T = TypeVar("T")
+
+_metadata = MetaData()
+_dataclass_metadata = MetaData()
+
+#: target_type seen by the from-SA / to-SA converters, newest last.
+seen_from_sa_target_types: list[Any] = []
+seen_to_sa_target_types: list[Any] = []
+
+
+def _meta_to_json(value: BaseModel | None, context: ConversionContext) -> Any:
+    seen_to_sa_target_types.append(context.target_type)
+    return None if value is None else value.model_dump(mode="json")
+
+
+def _meta_from_json(value: Any, context: ConversionContext) -> Any:
+    seen_from_sa_target_types.append(context.target_type)
+    return None if value is None else TypeAdapter(context.target_type).validate_python(value)
+
+
+def _record_to_sa(value: Any, context: ConversionContext) -> Any:
+    seen_to_sa_target_types.append(context.target_type)
+    return value
+
+
+def _record_from_sa(value: Any, context: ConversionContext) -> Any:
+    seen_from_sa_target_types.append(context.target_type)
+    return value
+
+
+class _MediaItemBase(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": _metadata}
+
+
+class MediaItem(_MediaItemBase, Generic[D]):
+    __sqlalchemy_params__ = {
+        "__tablename__": "cc_media_item",
+        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_abstract": True},
+    }
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    kind: Annotated[str, mapped_column(String, nullable=False)]
+    meta: Annotated[
+        D | None,
+        mapped_column(JSON, nullable=True),
+        ConvertToSAWith(_meta_to_json),
+        ConvertFromSAWith(_meta_from_json),
+    ] = None
+
+
+class PhotoMeta(BaseModel):
+    width: int
+    height: int
+
+
+class VideoMeta(BaseModel):
+    duration_seconds: float
+
+
+class Photo(MediaItem[PhotoMeta]):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "photo"}}
+    kind: Annotated[str, ExcludeSAField()] = "photo"
+
+
+class Video(MediaItem[VideoMeta]):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "video"}}
+    kind: Annotated[str, ExcludeSAField()] = "video"
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorders() -> None:
+    seen_from_sa_target_types.clear()
+    seen_to_sa_target_types.clear()
+
+
+@pytest.mark.parametrize(
+    ("make_item", "meta_type"),
+    [
+        (lambda: Photo(meta=PhotoMeta(width=4, height=3)), PhotoMeta),
+        (lambda: Video(meta=VideoMeta(duration_seconds=12.5)), VideoMeta),
+    ],
+    ids=["photo", "video"],
+)
+def test_generic_subclass_converters_see_the_specialised_field_type(
+    make_item: Callable[[], Photo] | Callable[[], Video], meta_type: type
+) -> None:
+    item = make_item()
+
+    sa_model = item.to_sa_model()
+    assert isinstance(sa_model.meta, dict)
+    assert seen_to_sa_target_types[-1] == meta_type | None
+
+    loaded = type(item).from_sa_model(sa_model)
+    assert isinstance(loaded.meta, meta_type)
+    assert loaded.meta == item.meta
+    assert seen_from_sa_target_types[-1] == meta_type | None
+
+
+def test_none_payload_round_trips_without_validation() -> None:
+    loaded = Photo.from_sa_model(Photo(meta=None).to_sa_model())
+    assert loaded.meta is None
+    assert seen_from_sa_target_types[-1] == PhotoMeta | None
+
+
+class _DataclassBase(SQLCrucibleEntity):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": _dataclass_metadata}
+
+
+@dataclass(kw_only=True)
+class Box(_DataclassBase, Generic[T]):
+    """A non-Pydantic (dataclass) generic entity — its field type ``T`` is
+    resolved by substituting the binding from a concrete subclass, with no
+    help from Pydantic's ``model_fields``."""
+
+    __sqlalchemy_params__ = {"__abstract__": True}
+    value: Annotated[
+        T,
+        mapped_column(Integer, nullable=True),
+        ConvertToSAWith(_record_to_sa),
+        ConvertFromSAWith(_record_from_sa),
+    ]
+    siblings: Annotated[list[T], ExcludeSAField()] = field(default_factory=list)
+
+
+@dataclass(kw_only=True)
+class IntBox(Box[int]):
+    __sqlalchemy_params__ = {"__tablename__": "cc_int_box"}
+    id: Annotated[UUID, mapped_column(primary_key=True)] = field(default_factory=uuid4)
+
+
+@pytest.mark.parametrize(
+    ("source_name", "expected"),
+    [("value", int), ("siblings", list[int])],
+    ids=["bare-typevar", "list-of-typevar"],
+)
+def test_typevars_resolved_for_non_pydantic_generic_subclass(
+    source_name: str, expected: Any
+) -> None:
+    assert entity_field_type(IntBox, source_name) == expected
+
+
+def test_non_pydantic_generic_converters_see_the_specialised_field_type() -> None:
+    sa_model = IntBox(value=7).to_sa_model()
+    assert seen_to_sa_target_types[-1] is int
+
+    loaded = IntBox.from_sa_model(sa_model)
+    assert loaded.value == 7
+    assert seen_from_sa_target_types[-1] is int

--- a/tests/entity/test_dataclass_entity.py
+++ b/tests/entity/test_dataclass_entity.py
@@ -46,8 +46,8 @@ class Track(BaseTestEntity):
         timedelta,
         mapped_column(),
         SQLAlchemyField(name="length_seconds", tp=int),
-        ConvertToSAWith(lambda td: td.total_seconds()),
-        ConvertFromSAWith(lambda it: timedelta(seconds=it)),
+        ConvertToSAWith(lambda td, ctx: td.total_seconds()),
+        ConvertFromSAWith(lambda it, ctx: timedelta(seconds=it)),
     ]
     notes: Annotated[str | None, mapped_column(nullable=True)] = None
 

--- a/tests/entity/test_pydantic_entity.py
+++ b/tests/entity/test_pydantic_entity.py
@@ -42,8 +42,8 @@ class Track(BaseTestEntity):
         timedelta,
         mapped_column(),
         SQLAlchemyField(name="length_seconds", tp=int),
-        ConvertToSAWith(lambda td: td.total_seconds()),
-        ConvertFromSAWith(lambda it: timedelta(seconds=it)),
+        ConvertToSAWith(lambda td, ctx: td.total_seconds()),
+        ConvertFromSAWith(lambda it, ctx: timedelta(seconds=it)),
     ]
     notes: str | None = None
 


### PR DESCRIPTION
## What

`ConvertFromSAWith` / `ConvertToSAWith` callables now receive `(value, context)` rather than just `value`. `context` is a new `ConversionContext` dataclass; for now it carries a single field, `target_type` — the *resolved* entity-side type of the field being converted. For a concrete specialisation of a generic entity that's the specialised type, not the declared `TypeVar`, so a converter can validate against it directly.

`ConversionContext` is a dataclass (rather than the type being a bare extra parameter) purely so more context can be added later without another breaking signature change.

The `Converter` protocol gains the same `context` parameter on `convert` / `safe_convert`; it's threaded through the built-in converters (no-op, literal, sequence, dict, union, caching, to/from-SA-model) and the entity conversion machinery.

Field-type resolution is uniform across entity backends, not just Pydantic. For non-Pydantic (dataclass / attrs) entities the declared type's type variables are substituted using the bindings from the entity's generic specialisation — `get_type_params_for_base` walks the MRO for the bindings, and the field's declared type is re-subscripted on its free parameters (which every generic-alias form, including `types.UnionType`, supports).

## Why

A JSON column on a generic entity that stores a different Pydantic payload per subclass couldn't be re-validated to the right model from a `ConvertFromSAWith` callable, because the callable had no way to know which concrete type the field had been specialised to. The context gives it that.

## Example

```python
from typing import Annotated, Generic, TypeVar
from pydantic import BaseModel, TypeAdapter
from sqlalchemy import JSON
from sqlalchemy.orm import mapped_column
from sqlcrucible import ConvertFromSAWith, ConvertToSAWith, ExcludeSAField, SQLCrucibleBaseModel

P = TypeVar("P", bound=BaseModel)


class ReleaseEvent(SQLCrucibleBaseModel, Generic[P]):
    __sqlalchemy_params__ = {
        "__tablename__": "release_event",
        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_abstract": True},
    }
    payload: Annotated[
        P | None,
        mapped_column(JSON, nullable=True),
        ConvertToSAWith(lambda v, ctx: None if v is None else v.model_dump(mode="json")),
        ConvertFromSAWith(
            lambda v, ctx: None if v is None else TypeAdapter(ctx.target_type).validate_python(v)
        ),
    ] = None


class SinglePayload(BaseModel):
    a_side: str
    b_side: str


class SingleReleased(ReleaseEvent[SinglePayload]):
    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "single.released"}}
    kind: Annotated[str, ExcludeSAField()] = "single.released"


# Loading a SingleReleased row: ctx.target_type is `SinglePayload | None`,
# so `payload` comes back as a SinglePayload, not the raw stored dict.
```

Plain `Converter` implementations registered directly in a `ConverterRegistry` follow the same shape — `convert(self, source, context)` / `safe_convert(self, source, context)`.

## Internal restructuring

- `__sqlcrucible_fields__` is now a cached classmethod returning the merged (own + inherited, bases-first) field registry. Per-class declared fields live in `__own_sqlcrucible_fields__`.
- Each `SQLCrucibleField` records its declaring `owner`, so converter resolution reads the SA-side type from the automodel where the field's `Mapped[...]` annotation actually lives (matters for generic fields — the annotation carries the unsubstituted `TypeVar` on the declaring class's automodel only).
- `ReadonlyFieldDescriptor` resolves its converter/context per accessing class (keyed on the owner) rather than caching a single value on the descriptor, so an inherited readonly field on a concrete generic specialisation sees the specialised type.

## Breaking changes

- `ConvertFromSAWith` / `ConvertToSAWith` callables must take a second `context` parameter.
- Custom `Converter` implementations must take `context` on `convert` / `safe_convert`.
- `SQLCrucibleField` now requires an `owner` argument (internal type, but it's importable).