### PR TITLE
Fix from_sa_model polymorphic dispatch through a generic STI root

### DIFF
--- a/src/sqlcrucible/entity/core.py
+++ b/src/sqlcrucible/entity/core.py
@@ -278,7 +278,11 @@ class SQLCrucibleEntity:
 
         This method converts a SQLAlchemy model instance into the corresponding
         entity class. For polymorphic models, it automatically selects the most
-        specific entity subclass that matches the model type.
+        specific entity subclass that matches the model type — searching the
+        whole subclass subtree, not just ``cls``'s direct children, so that a
+        polymorphic query through a *generic* STI root reaches the named
+        concrete subclasses rather than only the transparent ``Foo[X]``
+        parameterisations that share the root's automodel.
 
         Args:
             sa_model: A SQLAlchemy model instance to convert.
@@ -302,15 +306,18 @@ class SQLCrucibleEntity:
                 f"Hint: Make sure you're passing a SQLAlchemy model that was created from "
                 f"this entity class or one of its subclasses."
             )
-        best_subclasses = sorted(
-            cls.__subclasses__(),
-            key=lambda it: mro_distance(sa_model.__class__, it.__sqlalchemy_type__),
-        )
-        if best_subclasses:
-            best_match = best_subclasses[0]
-        else:
-            best_match = cls
+        sa_class = sa_model.__class__
 
+        def subtree(entity: type[Any]) -> Iterator[type[Any]]:
+            yield entity
+            for subclass in entity.__subclasses__():
+                yield from subtree(subclass)
+
+        best_match = min(
+            (entity for entity in subtree(cls) if issubclass(sa_class, entity.__sqlalchemy_type__)),
+            key=lambda entity: mro_distance(sa_class, entity.__sqlalchemy_type__),
+            default=cls,
+        )
         return best_match._from_sa_model(sa_model)
 
     @classmethod

--- a/tests/entity/test_generic_sti.py
+++ b/tests/entity/test_generic_sti.py
@@ -100,6 +100,37 @@ def test_polymorphic_query_through_root_dispatches_to_subclass(engine):
     assert isinstance(row, SAType[Single])
 
 
+def test_from_sa_model_through_generic_root_yields_the_named_subclass(engine):
+    """A heterogeneous polymorphic query through the generic STI root, fed
+    back through ``Release.from_sa_model`` (not ``Single``/``Album``
+    directly), yields the named concrete subclass for each row — with its
+    ``details`` re-validated to that subclass's parameterised type. The
+    search has to walk past the transparent ``Release[SingleDetails]`` /
+    ``Release[AlbumDetails]`` parameterisations (which share the root's
+    automodel) to reach ``Single`` / ``Album``."""
+    with Session(engine) as session:
+        session.add(
+            Single(details=SingleDetails(a_side="Heroes", b_side="V-2 Schneider")).to_sa_model()
+        )
+        session.add(
+            Album(
+                details=AlbumDetails(track_titles=["Speed of Life", "Breaking Glass"])
+            ).to_sa_model()
+        )
+        session.commit()
+
+        rows = session.execute(select(SAType[Release])).scalars().all()
+
+    by_kind = {row.kind: Release.from_sa_model(row) for row in rows}
+
+    assert isinstance(by_kind["single"], Single)
+    assert by_kind["single"].details == SingleDetails(a_side="Heroes", b_side="V-2 Schneider")
+    assert isinstance(by_kind["album"], Album)
+    assert by_kind["album"].details == AlbumDetails(
+        track_titles=["Speed of Life", "Breaking Glass"]
+    )
+
+
 def test_stub_generation_is_well_formed(tmp_path: Path):
     """No bracket-named automodel class is created, so the generated
     stubs contain no class whose name has ``[`` ``]``; the parameterised


### PR DESCRIPTION
`from_sa_model` only searched `cls.__subclasses__()` — the *direct* children. For a Pydantic-generic single-table-inheritance root, those direct children are the transparent `Foo[X]` parameterisations (which all reuse the root's automodel, so they're indistinguishable by `mro_distance`), and the named concrete subclasses sit one level *below* them. So a polymorphic query fed back through the root never reached the concrete subclasses — it picked the first parameterisation and built every loaded row against *that* one's field types.

Minimal repro (songs / albums):

```python
class Release(SQLCrucibleBaseModel, Generic[D]):  # __abstract__ base above, polymorphic_on="kind", polymorphic_abstract
    kind: Annotated[str, mapped_column()]
    details: Annotated[D, mapped_column(PydanticJSON, nullable=True)]

class Single(Release[SingleDetails]):
    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "single"}}
    kind: Annotated[str, ExcludeSAField()] = "single"

class Album(Release[AlbumDetails]):
    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "album"}}
    kind: Annotated[str, ExcludeSAField()] = "album"

row = session.execute(select(SAType[Release])).scalar_one()   # an Album row
Release.from_sa_model(row)                                     # ← validated `details` against SingleDetails, blew up
```

`Single.from_sa_model(row)` worked; only dispatch *through the generic root* was broken. `test_polymorphic_query_through_root_dispatches_to_subclass` didn't catch it because it only asserts the *SQLAlchemy* row is the right subclass, never `Release.from_sa_model(row)`.

The fix: walk the whole subclass subtree (not just direct children), keep only entities whose automodel is `sa_model.__class__` or an ancestor of it, and pick the closest by `mro_distance` (falling back to `cls`). This also fixes the narrower case where a non-generic root had unrelated subclasses and the old code still preferred one of them over `cls` itself.

Adds a regression test: a heterogeneous polymorphic query through the root, fed back through `Release.from_sa_model`, must yield the right named subclass per row with `details` re-validated to that subclass's parameterised type. Full suite (450 tests), ruff, ty, and pyright all green.