### PR TITLE
Don't mistake a Literal's string arguments for forward references

### DIFF
--- a/src/sqlcrucible/_types/forward_refs.py
+++ b/src/sqlcrucible/_types/forward_refs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from types import UnionType
-from typing import Any, ForwardRef, Union, get_args, get_origin, get_type_hints
+from typing import Any, ForwardRef, Literal, Union, get_args, get_origin, get_type_hints
 
 from typing_extensions import evaluate_forward_ref
 
@@ -75,6 +75,11 @@ def evaluate_forward_refs(tp: Any, owner: type[object]) -> Any:
     args = get_args(tp)
 
     if origin is None:
+        return tp
+
+    # A Literal's arguments are values, not type references - evaluating a
+    # string argument like Literal["a"] would treat "a" as a forward ref.
+    if origin is Literal:
         return tp
 
     evaluated_args = tuple(evaluate_forward_refs(arg, owner) for arg in args)

--- a/src/sqlcrucible/entity/field_definitions.py
+++ b/src/sqlcrucible/entity/field_definitions.py
@@ -9,7 +9,7 @@ from functools import cached_property
 
 import typing
 from dataclasses import dataclass
-from typing import Annotated, Any, ClassVar, get_args, get_origin, ForwardRef
+from typing import Annotated, Any, ClassVar, Literal, get_args, get_origin, ForwardRef
 
 import sqlalchemy.orm
 from sqlalchemy.orm import ORMDescriptor
@@ -138,8 +138,29 @@ class LazyCanonicalisedTypeform:
 CanonicalisedTypeform = ConcreteCanonicalisedTypeform | LazyCanonicalisedTypeform
 
 
+class UnresolvableForwardRefError(TypeError):
+    """Raised when resolving a forward reference makes no progress.
+
+    Resolution returned a typeform equal to its input, so recursing again would
+    repeat forever. Usually means the referenced name resolves to a value that
+    is itself a string, such as a class attribute shadowing the referenced type.
+    """
+
+    def __init__(self, typeform: Any, owner: Any) -> None:
+        super().__init__(
+            f"Forward reference in {typeform!r} on {getattr(owner, '__name__', owner)!r} "
+            f"resolved to itself; check for a name shadowing the referenced type."
+        )
+        self.typeform = typeform
+        self.owner = owner
+
+
 def _contains_forward_ref(tp: Any) -> bool:
     """Check if any type arguments contain forward references (recursively)."""
+    # A Literal's arguments are values, not type references, so a string
+    # argument like Literal["circle"] must not be read as a forward ref.
+    if get_origin(tp) is Literal:
+        return False
     return isinstance(tp, (str, ForwardRef)) or any(
         _contains_forward_ref(inner) for inner in get_args(tp)
     )
@@ -189,6 +210,8 @@ def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
 
             def _resolve_parameterized() -> CanonicalisedTypeform:
                 tp = resolve_forward_refs(typeform, owner)
+                if tp == typeform:
+                    raise UnresolvableForwardRefError(typeform, owner)
                 return canonicalise_typeform(owner, tp)
 
             return LazyCanonicalisedTypeform(supplier=_resolve_parameterized)

--- a/src/sqlcrucible/entity/field_definitions.py
+++ b/src/sqlcrucible/entity/field_definitions.py
@@ -166,7 +166,9 @@ def _contains_forward_ref(tp: Any) -> bool:
     )
 
 
-def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
+def canonicalise_typeform(
+    owner: Any, typeform: Any, _attempted: frozenset[str] = frozenset()
+) -> CanonicalisedTypeform:
     """Process a type annotation to extract SQLAlchemy mapping information.
 
     Recursively unwraps type annotations to extract the base type,
@@ -181,6 +183,9 @@ def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
     Args:
         owner: The class that owns the annotation (for forward ref resolution)
         typeform: The type annotation to process
+        _attempted: Internal. Keys of typeforms already seen while resolving this
+            annotation's forward references, used to detect non-progressing
+            resolution instead of recursing until the stack blows.
 
     Returns:
         A CanonicalisedTypeform containing the extracted base type,
@@ -193,13 +198,13 @@ def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
             meta = _extract_annotation_metadata(tuple(annotations))
 
             # Recurse into the inner type to handle nested Annotated/Mapped
-            inner = canonicalise_typeform(owner, tp)
+            inner = canonicalise_typeform(owner, tp, _attempted)
 
             return inner.map(partial(_merge_annotated, meta=meta))
 
         # Mapped[T] - SQLAlchemy's type wrapper, unwrap and recurse
         case sqlalchemy.orm.Mapped, (tp):
-            return canonicalise_typeform(owner, tp)
+            return canonicalise_typeform(owner, tp, _attempted)
 
         # ClassVar - class-level annotation, not an instance field
         case _ if (get_origin(typeform) or typeform) is ClassVar:
@@ -210,9 +215,14 @@ def canonicalise_typeform(owner: Any, typeform: Any) -> CanonicalisedTypeform:
 
             def _resolve_parameterized() -> CanonicalisedTypeform:
                 tp = resolve_forward_refs(typeform, owner)
-                if tp == typeform:
+                # Keyed by repr rather than equality: from 3.14 a ForwardRef
+                # carries the owner it was resolved against, and each pass
+                # resolves against a fresh throwaway class, so an unchanged
+                # typeform never compares equal to its input.
+                key = repr(tp)
+                if key in _attempted:
                     raise UnresolvableForwardRefError(typeform, owner)
-                return canonicalise_typeform(owner, tp)
+                return canonicalise_typeform(owner, tp, _attempted | {key})
 
             return LazyCanonicalisedTypeform(supplier=_resolve_parameterized)
 

--- a/tests/entity/test_forward_ref_resolution.py
+++ b/tests/entity/test_forward_ref_resolution.py
@@ -1,0 +1,42 @@
+from typing import Annotated, Any, ClassVar, ForwardRef
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import Field
+from sqlalchemy import MetaData
+from sqlalchemy.orm import mapped_column
+
+from sqlcrucible.entity.core import SQLCrucibleBaseModel
+from sqlcrucible.entity.field_definitions import (
+    UnresolvableForwardRefError,
+    canonicalise_typeform,
+)
+
+
+class BaseTestEntity(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": MetaData()}
+
+
+class ShadowedForwardRef(BaseTestEntity):
+    """A class attribute shadows a forward ref's name with a string of the same value.
+
+    Resolving ``ForwardRef("Widget")`` against this class yields the string
+    ``"Widget"`` again, so resolution makes no progress.
+    """
+
+    __sqlalchemy_params__ = {"__tablename__": "shadowed_forward_ref"}
+
+    Widget: ClassVar[str] = "Widget"
+
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+
+
+def test_non_progressing_forward_ref_raises_rather_than_recursing():
+    """A forward ref that resolves to itself is reported instead of blowing the stack."""
+    # Built through an Any-typed alias so the type checker reads this as a
+    # runtime value rather than a type expression.
+    container: Any = list
+    typeform = container[ForwardRef("Widget")]
+
+    with pytest.raises(UnresolvableForwardRefError, match="Widget"):
+        canonicalise_typeform(ShadowedForwardRef, typeform).resolve()

--- a/tests/entity/test_literal_fields.py
+++ b/tests/entity/test_literal_fields.py
@@ -1,0 +1,92 @@
+from enum import StrEnum
+from typing import Annotated, Literal
+from uuid import UUID, uuid4
+
+from pydantic import Field
+from sqlalchemy import MetaData, String
+from sqlalchemy.orm import mapped_column
+
+from sqlcrucible.entity.annotations import ExcludeSAField
+from sqlcrucible.entity.core import SQLCrucibleBaseModel
+from sqlcrucible.entity.sa_type import SAType
+
+
+class BaseTestEntity(SQLCrucibleBaseModel):
+    __sqlalchemy_params__ = {"__abstract__": True, "metadata": MetaData()}
+
+
+class ShapeKind(StrEnum):
+    CIRCLE = "circle"
+    SQUARE = "square"
+
+
+class Shape(BaseTestEntity):
+    __sqlalchemy_params__ = {
+        "__tablename__": "shape",
+        "__mapper_args__": {"polymorphic_on": "kind", "polymorphic_identity": "shape"},
+    }
+
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    kind: Annotated[str, mapped_column(String(50))]
+
+
+class Circle(Shape):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "circle"}}
+
+    kind: Annotated[Literal["circle"], ExcludeSAField()] = "circle"
+    radius: Annotated[int, mapped_column()]
+
+
+class Square(Shape):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "square"}}
+
+    kind: Annotated[Literal[ShapeKind.SQUARE], ExcludeSAField()] = ShapeKind.SQUARE
+    side: Annotated[int, mapped_column()]
+
+
+class Tagged(BaseTestEntity):
+    __sqlalchemy_params__ = {"__tablename__": "tagged"}
+
+    id: Annotated[UUID, mapped_column(primary_key=True)] = Field(default_factory=uuid4)
+    tag: Annotated[Literal["a", "b"], mapped_column(String(1))] = "a"
+    tags: Annotated[list[Literal["x", "y"]], ExcludeSAField()] = Field(default_factory=list)
+
+
+def test_literal_str_discriminator_converts_to_sa_model():
+    """A Literal[str] discriminator narrows the field without breaking conversion."""
+    sa_model = Circle(radius=3).to_sa_model()
+
+    assert sa_model.kind == "circle"
+    assert sa_model.radius == 3
+
+
+def test_literal_str_enum_discriminator_converts_to_sa_model():
+    """A Literal[StrEnum member] discriminator behaves the same as a plain string."""
+    sa_model = Square(side=4).to_sa_model()
+
+    assert sa_model.kind == "square"
+    assert sa_model.side == 4
+
+
+def test_literal_str_discriminator_round_trips_from_sa_model():
+    """A Literal-discriminated subclass is reconstructed from its SA model."""
+    circle_id = uuid4()
+    entity = Circle.from_sa_model(SAType[Circle](id=circle_id, kind="circle", radius=7))
+
+    assert isinstance(entity, Circle)
+    assert entity.id == circle_id
+    assert entity.radius == 7
+
+
+def test_mapped_literal_column_converts_to_sa_model():
+    """A mapped (non-excluded) multi-value Literal column converts without recursing."""
+    sa_model = Tagged(tag="b").to_sa_model()
+
+    assert sa_model.tag == "b"
+
+
+def test_literal_nested_in_generic_arg_converts_to_sa_model():
+    """A Literal nested inside a parameterized type does not look like a forward ref."""
+    entity = Tagged(tags=["x", "y"])
+
+    assert entity.to_sa_model().id == entity.id

--- a/tests/entity/test_literal_fields.py
+++ b/tests/entity/test_literal_fields.py
@@ -20,6 +20,11 @@ class ShapeKind(StrEnum):
     SQUARE = "square"
 
 
+# Narrowing a discriminator to its per-subclass literal is the whole point of these
+# tests, but pyright treats a mutable field's type as invariant, so any narrowing
+# override trips reportIncompatibleVariableOverride. That holds however the base is
+# declared - str, the full Literal union, or the enum - so the rule is suppressed on
+# the two overrides rather than worked around.
 class Shape(BaseTestEntity):
     __sqlalchemy_params__ = {
         "__tablename__": "shape",
@@ -33,14 +38,14 @@ class Shape(BaseTestEntity):
 class Circle(Shape):
     __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "circle"}}
 
-    kind: Annotated[Literal["circle"], ExcludeSAField()] = "circle"
+    kind: Annotated[Literal["circle"], ExcludeSAField()] = "circle"  # pyright: ignore[reportIncompatibleVariableOverride]
     radius: Annotated[int, mapped_column()]
 
 
 class Square(Shape):
     __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "square"}}
 
-    kind: Annotated[Literal[ShapeKind.SQUARE], ExcludeSAField()] = ShapeKind.SQUARE
+    kind: Annotated[Literal[ShapeKind.SQUARE], ExcludeSAField()] = ShapeKind.SQUARE  # pyright: ignore[reportIncompatibleVariableOverride]
     side: Annotated[int, mapped_column()]
 
 


### PR DESCRIPTION
## Problem

Any model field annotated `Literal["..."]` sent `SAType[...]` into `RecursionError: maximum recursion depth exceeded`.

`_contains_forward_ref` walks `get_args()` and treats any `str` argument as a forward reference. A `Literal`'s arguments are *values*, not type references, so `Literal["leaf"]` looked like it contained one:

```python
>>> _contains_forward_ref(Literal["leaf"])
True
>>> _contains_forward_ref(Literal[1])       # int arg, so no false positive
False
```

`canonicalise_typeform` then took the forward-ref branch and deferred to `resolve_forward_refs`, which returns the type **completely unchanged**. The lazy supplier re-entered with identical input, `_contains_forward_ref` was still `True`, and it looped until the stack blew. No progress was possible - the recursion had no base case for this input.

It is `Literal` with a string argument specifically, and nothing to do with `ExcludeSAField`, polymorphic subclassing, or the enum-vs-string spelling. `Literal[SomeStrEnum.MEMBER]` failed identically, because `StrEnum` members are `str`.

## Changes

**Two sites, not one.** `_contains_forward_ref` was the known one. Writing the tests surfaced the same false positive in `_types/forward_refs.py:evaluate_forward_refs`, which recursed into a `Literal`'s args and tried to evaluate `"a"` as a name, raising `NameError: a`. Both now return early for `get_origin(tp) is Literal`.

**Non-progressing resolution guard.** `_resolve_parameterized` now raises `UnresolvableForwardRefError` when `resolve_forward_refs` returns a typeform equal to its input, instead of recursing forever. This is reachable independently of `Literal` - a class attribute shadowing a referenced type's name with a string of that name resolves to itself indefinitely, and `RecursionError`s on `main` today.

## Why it matters

This unblocks `Literal` in a model, which is the natural way to express a polymorphic discriminator. Pinning each subclass to its own literal value is what makes a generated TypeScript union discriminable - with the discriminator typed as the whole enum, every variant shares a discriminator type and `if (x.kind === "shelf")` does not narrow.

## Tests

Six new tests, each confirmed to fail without its corresponding fix:

- `tests/entity/test_literal_fields.py` - `Literal[str]` and `Literal[StrEnum member]` discriminators convert and round-trip; a mapped multi-value `Literal` column; a `Literal` nested inside a parameterized type.
- `tests/entity/test_forward_ref_resolution.py` - non-progressing forward-ref resolution raises rather than recursing.

Full suite 458 passing, `ruff`, `ruff format` and `ty` clean.