### PR TITLE
Document narrowing polymorphic discriminators to Literal

### DIFF
--- a/docs/guide/inheritance.md
+++ b/docs/guide/inheritance.md
@@ -104,6 +104,41 @@ class Dog(Animal):
 !!! warning
     Concrete table inheritance requires redefining ALL columns in each subclass.
 
+## Narrowing the discriminator
+
+The examples above type the discriminator as `str`, which is the simplest thing that works. The cost shows up when you generate a client from these models: every subclass declares the same discriminator type, so the generated union carries no information about which variant you have.
+
+```ts
+// Every variant says `type: string`, so this does not narrow
+if (animal.type === "dog") {
+  animal.bones_chewed;  // not accessible without a cast
+}
+```
+
+Pin each subclass to its own value instead, using `Literal`:
+
+```python
+from typing import Annotated, Literal
+
+class Dog(Animal):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "dog"}}
+    bones_chewed: Annotated[int | None, mapped_column(nullable=True)] = None
+    type: Annotated[Literal["dog"], ExcludeSAField()] = "dog"  # pyright: ignore[reportIncompatibleVariableOverride]
+
+class Cat(Animal):
+    __sqlalchemy_params__ = {"__mapper_args__": {"polymorphic_identity": "cat"}}
+    hours_napped: Annotated[int | None, mapped_column(nullable=True)] = None
+    type: Annotated[Literal["cat"], ExcludeSAField()] = "cat"  # pyright: ignore[reportIncompatibleVariableOverride]
+```
+
+`Literal` also accepts enum members, so `Literal[AnimalType.DOG]` works if your discriminator is a `StrEnum`.
+
+!!! warning "Keep `ExcludeSAField()`"
+    The narrowed annotation still redeclares a column that already exists on the parent, so it needs `ExcludeSAField()` exactly as the `str` version did. A bare `Literal["dog"]` fails at import with `Column 'type' on class DogAutoModel conflicts with existing column 'animal.type'`.
+
+!!! note "Pyright reports an override error"
+    Pyright treats a mutable field's type as invariant, so narrowing an inherited field trips `reportIncompatibleVariableOverride`. No base declaration avoids this - `str`, the full `Literal["dog", "cat"]` union, and a `StrEnum` all report it - so suppress the rule per declaration as above, or disable it for your models module. This is a type checker limitation rather than a SQLCrucible one, and `ty` does not report it.
+
 ## Polymorphic Round-Trip
 
 When using inheritance, `from_sa_model()` automatically returns the correct subclass:


### PR DESCRIPTION
Closes the docs gap left by 0.5.1, which made `Literal` usable in a model. Narrowing a polymorphic discriminator to its per-subclass value is the headline use of that fix, but the inheritance guide only showed the open `str` spelling, so there was nothing telling readers the narrowing was possible, why they'd want it, or how to get past the two things that bite you.

Adds a "Narrowing the discriminator" section to `docs/guide/inheritance.md` covering:

- **The motivation.** An open discriminator means every subclass declares the same type, so a generated client union carries no information about which variant you have and `if (animal.type === "dog")` does not narrow.
- **`ExcludeSAField()` is still required.** The narrowed annotation redeclares a parent column exactly as the `str` version did. A bare `Literal["dog"]` fails at import.
- **Pyright reports an override error.** A mutable field's type is invariant, so narrowing an inherited field trips `reportIncompatibleVariableOverride`. No base declaration avoids it, so the section says to suppress per declaration or disable the rule for the models module, and notes `ty` does not report it.

## Verification

Every code example and both error claims were run against the released 0.5.1 rather than written from memory:

```
doc example works: dog cat
StrEnum member claim: dog
bare Literal error: Column 'type' on class Dog3AutoModel conflicts with existing column 'animal.type'
```

The pyright claim was checked against all three plausible base declarations (`str`, the full `Literal` union, and a `StrEnum`); all three report the error, which is why the section says there's no way to declare around it.

`mkdocs build --strict` passes and both new admonitions render.

## Note

The new heading is sentence case while the rest of the page is Title Case. Happy to switch it either way - say if you'd rather it matched the page, or if you want the page converted.